### PR TITLE
Add production backup and trusted edge hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ permissions:
   contents: read
 
 jobs:
+  verifyEdgeProxy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.0
+    - name: Verify trusted edge proxy sanitization
+      run: bash ./scripts/verify-edge-proxy.sh
+
   runDocker:
     runs-on: ubuntu-latest
     services:

--- a/GTP56_SOL_AUDIT.md
+++ b/GTP56_SOL_AUDIT.md
@@ -1,0 +1,261 @@
+# Awesome Testing Project Audit
+
+Audit date: 2026-07-17
+
+Scope:
+
+- `awesome-localstack`
+- `test-secure-backend`
+- `vite-react-frontend`
+- `jms-email-consumer`
+- `ollama-mock`
+- AI Testers course compatibility contract
+
+## Executive summary
+
+The application code is in good shape, but the production and release infrastructure still has several worthwhile improvements. The three most urgent areas are backups, container vulnerabilities, and proxy trust.
+
+Spring Boot is already on the current `4.1.0` release, production PostgreSQL is current at `16.14`, the frontend production npm audit reports zero vulnerabilities, and the owned backend, consumer, and mock images scanned clean for critical/high fixable findings. Broad application dependency modernization is therefore not the priority.
+
+Recommended execution order:
+
+1. Backup and restore automation.
+2. Nginx/frontend image release.
+3. Forwarded-IP trust fix.
+4. Mailpit and infrastructure image upgrades.
+5. CI and repository security controls.
+6. Messaging reliability.
+7. Authentication cookie migration.
+
+## Priority 0 — handle next
+
+### 1. Automate PostgreSQL backups and restore tests
+
+Production currently relies on the `postgres-data` Docker volume in `docker-compose.server.yml`, with no off-server backup.
+
+Add:
+
+- Daily encrypted `pg_dump` copied off the Mikrus server.
+- Retention, for example 7 daily and 4 weekly backups.
+- A pre-deployment backup.
+- A scheduled restore verification into a temporary database.
+
+This is the largest operational risk: a volume or server failure currently means permanent data loss.
+
+### 2. Rebuild and release the frontend on a safe nginx base
+
+The frontend uses `nginx:1.29.1-alpine`. The point-in-time Docker Scout scan reported 5 critical and 30 high fixable package findings.
+
+The gateway's `nginx:1.29.7-perl` also reported 22 high findings, and Perl is not used. Current nginx advisories list several issues fixed only in newer 1.30/1.31 releases.
+
+Recommendation:
+
+- Use `nginx:1.31.2-trixie` for frontend and gateway.
+- Drop the unnecessary `-perl` variant.
+- Run nginx unprivileged where feasible.
+- Add an image vulnerability gate to every release.
+
+The audit scan of `nginx:1.31.2-trixie` reported zero fixable critical/high findings.
+
+References:
+
+- <https://nginx.org/en/security_advisories.html>
+- <https://hub.docker.com/_/nginx>
+
+### 3. Fix trusted proxy and client-IP handling
+
+Nginx appends caller-controlled values using `$proxy_add_x_forwarded_for`, while the backend selects the first address from `X-Forwarded-For`.
+
+If the origin is reachable directly, callers can spoof the address used by rate limiting.
+
+Fix by:
+
+- Replacing the gateway header with `X-Forwarded-For $remote_addr`.
+- Alternatively, parsing forwarded headers only from explicitly trusted proxy CIDRs.
+- Restricting origin port 80 at the firewall where the hosting arrangement permits it.
+
+## Priority 1 — production hardening
+
+### 4. Replace MailHog with Mailpit
+
+`mailhog/mailhog:v1.0.1` dates from 2020 and its image reported 6 critical and 64 high fixable findings.
+
+Mailpit is actively maintained and SMTP-compatible. Its current `v1.30.4` image scanned with zero critical/high findings.
+
+References:
+
+- <https://github.com/mailhog/mailhog>
+- <https://mailpit.axllent.org/docs/install/docker/>
+
+### 5. Refresh infrastructure images in controlled batches
+
+Current production pins:
+
+- Grafana `11.5.1`; the current line is 13.x.
+- Prometheus `3.1.0`; the current line is 3.13.x.
+- Artemis `2.31.2`; the official current release found during the audit is 2.42.0.
+- Local Keycloak `26.0`; the current line is 26.7.
+- PostgreSQL `16.14` is already current and should remain as-is.
+
+Grafana and Artemis still have findings even on newer images, so scan and assess them rather than assuming an upgrade eliminates everything. Disable the Artemis web console and Jolokia in production if they are not required.
+
+References:
+
+- <https://grafana.com/docs/grafana/latest/whatsnew/>
+- <https://prometheus.io/download/>
+- <https://activemq.apache.org/components/artemis/download>
+- <https://www.keycloak.org/blog>
+- <https://www.postgresql.org/docs/16/release-16-14.html>
+
+### 6. Persist and harden message delivery
+
+Artemis currently uses an anonymous image volume. Give it a named volume so pending email messages survive controlled replacement and can be managed.
+
+The consumer should also gain:
+
+- Explicit redelivery limits and DLQ handling.
+- Idempotency protection against duplicate email delivery.
+- A real Artemis and SMTP integration test.
+- Message validation before sending.
+
+### 7. Strengthen GitHub controls
+
+Current state:
+
+- No default branch is protected.
+- Workflows run only on `push`, not explicitly on pull requests.
+- Consumer and mock have no CI workflows.
+- No repository has CodeQL analysis.
+- Secret scanning is disabled for localstack, backend, and consumer.
+- Actions are pinned to version tags, not immutable commit SHAs.
+
+Enable pull-request checks, protected branches, CodeQL, secret scanning, and SHA-pinned actions.
+
+References:
+
+- <https://docs.github.com/en/code-security/how-tos/find-and-fix-code-vulnerabilities/configure-code-scanning/configuring-default-setup-for-code-scanning>
+- <https://docs.github.com/en/actions/reference/security/secure-use>
+- <https://docs.github.com/en/repositories/configuring-branches-and-merges/managing-protected-branches/about-protected-branches>
+
+### 8. Make image versions a single source of truth
+
+Version drift is significant:
+
+- Production: backend `3.7.8`, frontend `3.7.4`.
+- CI/lightweight stack: backend `3.6.15`, frontend `3.6.16`.
+- `docker-run-all.sh`: backend/frontend `3.6.11`.
+- Frontend's own Compose file: backend `3.7.7`.
+
+Consequently, part of localstack CI validates an old application rather than the released stack. Introduce one release manifest or version environment file and update every Compose variant automatically.
+
+### 9. Improve session storage and browser headers
+
+Both access and refresh tokens are stored in `localStorage`. OWASP recommends not storing authentication or refresh tokens there because any XSS can read them.
+
+Preferred approach:
+
+- Store the refresh token in a `Secure; HttpOnly; SameSite` cookie.
+- Keep a short-lived access token in memory.
+- Preserve existing JSON token responses where needed for the course contract.
+- Add CSP, `Referrer-Policy`, `Permissions-Policy`, and frame protection to frontend and gateway responses.
+
+Live `/login` responses currently lack these application security headers.
+
+Reference:
+
+- <https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html>
+
+### 10. Add actionable monitoring
+
+Prometheus currently scrapes only the main backend and consumer, with no alerting.
+
+Add:
+
+- `aitesters-backend`, gateway, PostgreSQL, and Artemis health.
+- External HTTPS probes for both domains.
+- Alerting for availability, JVM pressure, database storage, and email queue depth.
+- Persistent Prometheus storage if monitoring history is useful.
+
+External monitoring is especially important because it would detect Mikrus or edge `520` failures even when containers remain locally healthy.
+
+## Priority 2 — quality and maintainability
+
+### 11. Enforce the existing frontend quality checks in CI
+
+Add frontend lint and `test:coverage` to CI. Both passed during the audit:
+
+- 60 test files passed.
+- 438 tests passed.
+- 89.33% line coverage.
+- 88.93% statement coverage.
+- 80.14% branch coverage.
+- 85.71% function coverage.
+
+The thresholds are configured but ordinary CI currently invokes only the standard test command and build.
+
+### 12. Harden the consumer configuration
+
+- Replace wildcard actuator exposure.
+- Stop returning stack traces and binding details by default.
+- Stop logging recipient email addresses.
+- Add CI for unit and integration tests.
+
+### 13. Harden the Ollama mock
+
+- Use a JRE rather than a full JDK for the runtime image.
+- Run as a non-root user.
+- Add a healthcheck.
+- Move prompt and per-token logging from `INFO` to `DEBUG` or `TRACE`.
+- Avoid logging potentially sensitive prompt content by default.
+
+### 14. Align Maven artifact versions with image releases
+
+Backend and consumer still identify as `1.0.0`, and the mock identifies as `0.0.1-SNAPSHOT`, despite Docker releases `3.7.8`, `3.3.3`, and `1.0.5`.
+
+Use one revision property per repository and make release tooling update it together with the image tag.
+
+### 15. Keep and tighten Flyway migrations
+
+Flyway migrations should remain permanently in source control.
+
+Recommended follow-up:
+
+- Disable `baseline-on-migrate` now that production is initialized.
+- Pin migration tests to PostgreSQL `16.14`.
+- Verify the expected Flyway schema version during deployment.
+- Never edit an applied migration; add a new migration instead.
+
+### 16. Formalize the course contract release gate
+
+Use the AI Testers course repository as a formal feedback loop:
+
+- Run the latest available lesson, currently `l12`, before deployment.
+- Optionally run all lesson folders nightly against the resettable environment.
+- Preserve behavior covered by the course tests.
+- Allow endpoints not covered by the course contract to evolve normally.
+
+Reference:
+
+- <https://github.com/AI-Testers-pl/ait2api1-api-ai/tree/master/l12>
+
+## Verified state during the audit
+
+- Latest GitHub Actions runs for localstack, backend, and frontend were green.
+- Both production domains returned HTTP 200 for `/login` and `/actuator/health`.
+- Frontend lint passed.
+- Frontend production `npm audit` reported zero vulnerabilities.
+- Frontend had only routine patch updates available; TypeScript 7, jsdom 29, and Node type definitions 26 should be handled separately as major upgrades.
+- Backend, consumer, and mock owned images reported zero critical/high fixable findings in the point-in-time Docker Scout scan.
+- All Compose files validated successfully with `docker compose config`.
+- Spring Boot `4.1.0` and PostgreSQL `16.14` are current.
+
+References:
+
+- <https://spring.io/blog/2026/06/10/spring-boot-4/>
+- <https://docs.docker.com/guides/docker-scout/>
+
+## Audit caveats
+
+Container scan counts are package-level, point-in-time findings, not proof that every reported vulnerability is exploitable in this deployment. They should be used for prioritization, followed by runtime and exposure assessment.
+
+The existing uncommitted Qwen/Ollama version edits were outside this audit and were left untouched.

--- a/ansible/inventory/group_vars/production/main.yml
+++ b/ansible/inventory/group_vars/production/main.yml
@@ -19,6 +19,7 @@ base_packages:
   - ca-certificates
   - curl
   - gnupg
+  - openssl
   - rsync
 
 ssh_hardening_enabled: true
@@ -43,6 +44,20 @@ journald_system_max_use: 100M
 journald_max_retention_sec: 14day
 
 app_compose_src: docker-compose.server.yml
+
+postgres_backup_enabled: true
+postgres_backup_root: /var/backups/awesome-localstack/postgres
+postgres_backup_environment_file: /etc/awesome-localstack/postgres-backup.env
+postgres_backup_daily_retention: 7
+postgres_backup_weekly_retention: 4
+postgres_backup_schedule: "*-*-* 02:15:00"
+postgres_restore_check_schedule: "Sun *-*-* 04:15:00"
+postgres_backup_pre_deploy: true
+postgres_backup_remote_target: "{{ backup_remote_target | default('', true) }}"
+postgres_backup_encryption_passphrase: "{{ backup_encryption_passphrase | default('', true) }}"
+postgres_backup_database: testdb
+postgres_backup_user: postgres
+postgres_restore_image: postgres:16.14-bookworm
 
 app_copy_paths:
   - nginx

--- a/ansible/inventory/group_vars/production/vault.yml.example
+++ b/ansible/inventory/group_vars/production/vault.yml.example
@@ -23,5 +23,14 @@ app_mfa_encryption_password: replace-with-at-least-32-random-characters
 app_mfa_encryption_salt: replace-with-at-least-16-random-bytes-in-hex
 # Rotating this value invalidates existing backend access tokens.
 jwt_secret_key: replace-with-at-least-32-random-bytes
+
+# Required when postgres_backup_enabled is true. Keep a separate offline copy:
+# losing this passphrase makes encrypted backups unrecoverable.
+backup_encryption_passphrase: replace-with-at-least-32-random-characters
+
+# Optional rsync destination for encrypted archives. The destination is expected
+# to exist and SSH host-key/authentication setup must already be configured.
+# Example: backup@example.net:/srv/backups/awesome-testing
+backup_remote_target: ""
 # Grants trusted E2E automation access to the protected aitesters email outbox.
 local_email_outbox_access_key: replace-with-at-least-32-random-bytes

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -4,5 +4,6 @@
   gather_facts: true
 
   roles:
+    - postgres_backup
     - app
     - verify

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -1,3 +1,23 @@
+- name: Check for an existing deployed Compose file
+  ansible.builtin.stat:
+    path: "{{ app_dir }}/{{ app_compose_file }}"
+  register: deployed_compose_file
+
+- name: Read the existing deployed Compose file
+  ansible.builtin.slurp:
+    path: "{{ app_dir }}/{{ app_compose_file }}"
+  register: deployed_compose_content
+  when: deployed_compose_file.stat.exists
+
+- name: Stop legacy public gateway before introducing the host-network edge
+  ansible.builtin.command:
+    cmd: docker compose -f {{ app_compose_file }} stop gateway
+    chdir: "{{ app_dir }}"
+  when:
+    - deployed_compose_file.stat.exists
+    - deployed_compose_content is defined
+    - "'\n  edge:' not in (deployed_compose_content.content | b64decode)"
+
 - name: Ensure application directory exists
   ansible.builtin.file:
     path: "{{ app_dir }}"
@@ -159,6 +179,7 @@
       - "{{ app_compose_file }}"
     services:
       - gateway
+      - edge
     recreate: always
     state: present
     wait: true

--- a/ansible/roles/postgres_backup/tasks/main.yml
+++ b/ansible/roles/postgres_backup/tasks/main.yml
@@ -1,0 +1,101 @@
+- name: Validate PostgreSQL backup encryption configuration
+  ansible.builtin.assert:
+    that:
+      - postgres_backup_encryption_passphrase | length >= 32
+    fail_msg: >-
+      Set backup_encryption_passphrase to at least 32 random characters in the
+      encrypted production vault before enabling PostgreSQL backups.
+    quiet: true
+  when: postgres_backup_enabled | bool
+
+- name: Ensure PostgreSQL backup directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+  loop:
+    - "{{ postgres_backup_root }}"
+    - "{{ postgres_backup_root }}/daily"
+    - "{{ postgres_backup_root }}/weekly"
+    - "{{ postgres_backup_environment_file | dirname }}"
+  when: postgres_backup_enabled | bool
+
+- name: Render PostgreSQL backup environment
+  ansible.builtin.template:
+    src: postgres-backup.env.j2
+    dest: "{{ postgres_backup_environment_file }}"
+    owner: root
+    group: root
+    mode: "0600"
+  when: postgres_backup_enabled | bool
+  no_log: true
+
+- name: Install PostgreSQL backup and restore verification scripts
+  ansible.builtin.template:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "0700"
+  loop:
+    - src: postgres-backup.sh.j2
+      dest: /usr/local/sbin/awesome-postgres-backup
+    - src: postgres-restore-check.sh.j2
+      dest: /usr/local/sbin/awesome-postgres-restore-check
+  when: postgres_backup_enabled | bool
+
+- name: Install PostgreSQL backup systemd units
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - awesome-postgres-backup.service
+    - awesome-postgres-backup.timer
+    - awesome-postgres-restore-check.service
+    - awesome-postgres-restore-check.timer
+  register: postgres_backup_systemd_units
+  when: postgres_backup_enabled | bool
+
+- name: Reload systemd after installing PostgreSQL backup units
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when:
+    - postgres_backup_enabled | bool
+    - postgres_backup_systemd_units is changed
+
+- name: Check whether the deployed PostgreSQL service is running
+  ansible.builtin.command:
+    cmd: docker compose -f {{ app_compose_file }} ps -q postgres
+    chdir: "{{ app_dir }}"
+  register: deployed_postgres_container
+  changed_when: false
+  failed_when: false
+  when:
+    - postgres_backup_enabled | bool
+    - postgres_backup_pre_deploy | bool
+
+- name: Create encrypted PostgreSQL backup before deployment
+  ansible.builtin.command:
+    cmd: /usr/local/sbin/awesome-postgres-backup pre-deploy
+  register: postgres_pre_deploy_backup
+  changed_when: true
+  when:
+    - postgres_backup_enabled | bool
+    - postgres_backup_pre_deploy | bool
+    - deployed_postgres_container.rc == 0
+    - deployed_postgres_container.stdout | trim | length > 0
+
+- name: Enable PostgreSQL backup and restore verification timers
+  ansible.builtin.systemd_service:
+    name: "{{ item }}"
+    enabled: true
+    state: started
+  loop:
+    - awesome-postgres-backup.timer
+    - awesome-postgres-restore-check.timer
+  when: postgres_backup_enabled | bool

--- a/ansible/roles/postgres_backup/templates/awesome-postgres-backup.service.j2
+++ b/ansible/roles/postgres_backup/templates/awesome-postgres-backup.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Encrypted PostgreSQL backup for Awesome Testing
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/flock --nonblock /run/awesome-postgres-backup.lock /usr/local/sbin/awesome-postgres-backup scheduled
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+NoNewPrivileges=true
+PrivateTmp=true
+TimeoutStartSec=30min

--- a/ansible/roles/postgres_backup/templates/awesome-postgres-backup.timer.j2
+++ b/ansible/roles/postgres_backup/templates/awesome-postgres-backup.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Daily encrypted PostgreSQL backup for Awesome Testing
+
+[Timer]
+OnCalendar={{ postgres_backup_schedule }}
+Persistent=true
+RandomizedDelaySec=15min
+Unit=awesome-postgres-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/postgres_backup/templates/awesome-postgres-restore-check.service.j2
+++ b/ansible/roles/postgres_backup/templates/awesome-postgres-restore-check.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Verify the latest Awesome Testing PostgreSQL backup
+Requires=docker.service
+After=docker.service awesome-postgres-backup.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/flock --nonblock /run/awesome-postgres-restore-check.lock /usr/local/sbin/awesome-postgres-restore-check
+Nice=10
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+NoNewPrivileges=true
+PrivateTmp=true
+TimeoutStartSec=30min

--- a/ansible/roles/postgres_backup/templates/awesome-postgres-restore-check.timer.j2
+++ b/ansible/roles/postgres_backup/templates/awesome-postgres-restore-check.timer.j2
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly restore verification for Awesome Testing PostgreSQL backups
+
+[Timer]
+OnCalendar={{ postgres_restore_check_schedule }}
+Persistent=true
+RandomizedDelaySec=15min
+Unit=awesome-postgres-restore-check.service
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/postgres_backup/templates/postgres-backup.env.j2
+++ b/ansible/roles/postgres_backup/templates/postgres-backup.env.j2
@@ -1,0 +1,9 @@
+APP_COMPOSE_FILE={{ (app_dir ~ '/' ~ app_compose_file) | quote }}
+BACKUP_ROOT={{ postgres_backup_root | quote }}
+BACKUP_DAILY_RETENTION={{ postgres_backup_daily_retention }}
+BACKUP_WEEKLY_RETENTION={{ postgres_backup_weekly_retention }}
+BACKUP_ENCRYPTION_PASSPHRASE={{ postgres_backup_encryption_passphrase | quote }}
+BACKUP_REMOTE_TARGET={{ postgres_backup_remote_target | quote }}
+POSTGRES_DATABASE={{ postgres_backup_database | quote }}
+POSTGRES_USER={{ postgres_backup_user | quote }}
+POSTGRES_RESTORE_IMAGE={{ postgres_restore_image | quote }}

--- a/ansible/roles/postgres_backup/templates/postgres-backup.sh.j2
+++ b/ansible/roles/postgres_backup/templates/postgres-backup.sh.j2
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+umask 077
+source {{ postgres_backup_environment_file }}
+export BACKUP_ENCRYPTION_PASSPHRASE
+
+backup_kind="${1:-scheduled}"
+if [[ ! "${backup_kind}" =~ ^[a-z0-9-]+$ ]]; then
+  echo "Backup kind must contain only lowercase letters, digits, and hyphens" >&2
+  exit 2
+fi
+daily_dir="${BACKUP_ROOT}/daily"
+weekly_dir="${BACKUP_ROOT}/weekly"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+backup_name="awesome-${POSTGRES_DATABASE}-${timestamp}-${backup_kind}.sql.gz.enc"
+backup_path="${daily_dir}/${backup_name}"
+temporary_path="$(mktemp "${daily_dir}/.${backup_name}.tmp.XXXXXX")"
+
+cleanup() {
+  if [[ -f "${temporary_path}" ]]; then
+    rm -f -- "${temporary_path}"
+  fi
+}
+trap cleanup EXIT
+
+retain_newest() {
+  local directory="$1"
+  local keep="$2"
+  local index
+  local -a backups
+
+  backups=()
+  while IFS= read -r backup; do
+    backups+=("${backup}")
+  done < <(find "${directory}" -maxdepth 1 -type f -name '*.sql.gz.enc' -print | sort -r)
+
+  index="${keep}"
+  while [[ -n "${backups[index]:-}" ]]; do
+    rm -f -- "${backups[index]}" "${backups[index]}.sha256"
+    index=$((index + 1))
+  done
+}
+
+echo "Creating encrypted PostgreSQL backup ${backup_path}"
+docker compose -f "${APP_COMPOSE_FILE}" exec -T postgres \
+  pg_dump \
+    --clean \
+    --if-exists \
+    --no-owner \
+    --no-privileges \
+    --username "${POSTGRES_USER}" \
+    --dbname "${POSTGRES_DATABASE}" \
+  | gzip -9 \
+  | openssl enc -aes-256-cbc -salt -pbkdf2 -iter 200000 \
+      -pass env:BACKUP_ENCRYPTION_PASSPHRASE \
+      -out "${temporary_path}"
+
+mv -- "${temporary_path}" "${backup_path}"
+(
+  cd "${daily_dir}"
+  sha256sum "${backup_name}" > "${backup_name}.sha256"
+)
+
+if [[ "$(date -u +%u)" == "7" ]]; then
+  weekly_path="${weekly_dir}/${backup_name}"
+  install -m 0600 "${backup_path}" "${weekly_path}"
+  (
+    cd "${weekly_dir}"
+    sha256sum "${backup_name}" > "${backup_name}.sha256"
+  )
+fi
+
+retain_newest "${daily_dir}" "${BACKUP_DAILY_RETENTION}"
+retain_newest "${weekly_dir}" "${BACKUP_WEEKLY_RETENTION}"
+
+if [[ -n "${BACKUP_REMOTE_TARGET}" ]]; then
+  rsync --archive --chmod=F600 \
+    "${backup_path}" "${backup_path}.sha256" \
+    "${BACKUP_REMOTE_TARGET%/}/"
+fi
+
+echo "PostgreSQL backup completed: ${backup_path}"

--- a/ansible/roles/postgres_backup/templates/postgres-restore-check.sh.j2
+++ b/ansible/roles/postgres_backup/templates/postgres-restore-check.sh.j2
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+umask 077
+source {{ postgres_backup_environment_file }}
+export BACKUP_ENCRYPTION_PASSPHRASE
+
+daily_dir="${BACKUP_ROOT}/daily"
+container_name="awesome-postgres-restore-check-$$"
+latest_backup="$(find "${daily_dir}" -maxdepth 1 -type f -name '*.sql.gz.enc' -print | sort -r | sed -n '1p')"
+
+if [[ -z "${latest_backup}" ]]; then
+  echo "No PostgreSQL backup is available for restore verification" >&2
+  exit 1
+fi
+
+backup_name="$(basename "${latest_backup}")"
+(
+  cd "${daily_dir}"
+  sha256sum --check "${backup_name}.sha256"
+)
+
+cleanup() {
+  docker rm --force "${container_name}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+if ! docker image inspect "${POSTGRES_RESTORE_IMAGE}" >/dev/null 2>&1; then
+  docker pull "${POSTGRES_RESTORE_IMAGE}"
+fi
+
+docker run --detach --rm \
+  --name "${container_name}" \
+  --tmpfs /var/lib/postgresql/data:rw,nosuid,nodev,size=1073741824 \
+  --env POSTGRES_PASSWORD=restore-check-only \
+  --env POSTGRES_DB=restorecheck \
+  "${POSTGRES_RESTORE_IMAGE}" >/dev/null
+
+for _ in $(seq 1 60); do
+  if docker exec "${container_name}" pg_isready --username postgres --dbname restorecheck >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+docker exec "${container_name}" pg_isready --username postgres --dbname restorecheck >/dev/null
+
+openssl enc -d -aes-256-cbc -pbkdf2 -iter 200000 \
+    -pass env:BACKUP_ENCRYPTION_PASSPHRASE \
+    -in "${latest_backup}" \
+  | gzip -dc \
+  | docker exec -i "${container_name}" \
+      psql --set ON_ERROR_STOP=1 --username postgres --dbname restorecheck >/dev/null
+
+table_count="$(
+  docker exec "${container_name}" \
+    psql --tuples-only --no-align --username postgres --dbname restorecheck \
+      --command "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';"
+)"
+
+if [[ ! "${table_count}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Restore verification completed but no public tables were found" >&2
+  exit 1
+fi
+
+echo "Restore verification passed for ${latest_backup} (${table_count} public tables)"

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -68,7 +68,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.29.7-perl
+    image: nginx:1.31.2-trixie
     restart: always
     depends_on:
       - frontend

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -60,7 +60,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.4
+    image: slawekradzyminski/frontend:3.7.5
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -104,7 +104,7 @@ services:
       - my-private-ntwk
 
   aitesters-frontend:
-    image: slawekradzyminski/frontend:3.7.4
+    image: slawekradzyminski/frontend:3.7.5
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -113,7 +113,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.29.7-perl
+    image: nginx:1.31.2-trixie
     restart: unless-stopped
     logging: *default-logging
     depends_on:
@@ -122,7 +122,7 @@ services:
       - aitesters-frontend
       - aitesters-backend
     ports:
-      - "80:80"
+      - "127.0.0.1:8080:80"
     volumes:
       - ./nginx/conf.d/app-gateway.conf:/etc/nginx/conf.d/default.conf:ro
       - ./images:/usr/share/nginx/html/images:ro
@@ -130,6 +130,17 @@ services:
       - ./nginx/conf.d/header-buffers.conf:/etc/nginx/conf.d/header-buffers.conf:ro
     networks:
       - my-private-ntwk
+
+  edge:
+    image: nginx:1.31.2-trixie
+    restart: unless-stopped
+    network_mode: host
+    logging: *default-logging
+    depends_on:
+      - gateway
+    volumes:
+      - ./nginx/conf.d/edge-gateway.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/conf.d/header-buffers.conf:/etc/nginx/conf.d/header-buffers.conf:ro
 
   prometheus:
     image: prom/prometheus:v3.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,7 +69,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.29.7-perl
+    image: nginx:1.31.2-trixie
     restart: always
     depends_on:
       - frontend

--- a/docs/PRODUCTION_BACKUPS.md
+++ b/docs/PRODUCTION_BACKUPS.md
@@ -1,0 +1,73 @@
+# Production PostgreSQL backups
+
+Production deployments install two systemd timers:
+
+- `awesome-postgres-backup.timer` creates a daily encrypted SQL archive.
+- `awesome-postgres-restore-check.timer` restores the newest archive into an
+  isolated disposable PostgreSQL container every week.
+
+The deployment also creates a backup immediately before replacing application
+containers when the production PostgreSQL service is running.
+
+## Required vault configuration
+
+Add a dedicated encryption passphrase to the encrypted production vault:
+
+```yaml
+backup_encryption_passphrase: a-separate-random-secret-of-at-least-32-characters
+```
+
+Keep an offline copy of this passphrase. The encrypted backups cannot be
+recovered without it.
+
+For off-host copies, configure an existing rsync destination:
+
+```yaml
+backup_remote_target: backup@example.net:/srv/backups/awesome-testing
+```
+
+The server's root account must already have SSH authentication and host-key
+verification configured for the destination. When the setting is empty, local
+encrypted backups and restore verification still run, but the setup does not
+protect against loss of the entire server.
+
+## Retention and locations
+
+By default, the server keeps:
+
+- 7 newest daily archives under
+  `/var/backups/awesome-localstack/postgres/daily`.
+- 4 newest Sunday archives under
+  `/var/backups/awesome-localstack/postgres/weekly`.
+
+Every encrypted archive has a SHA-256 checksum sidecar. No plaintext dump is
+written to disk.
+
+## Manual operations
+
+Create a backup:
+
+```bash
+sudo systemctl start awesome-postgres-backup.service
+sudo journalctl -u awesome-postgres-backup.service
+```
+
+Verify the newest backup by performing an isolated restore:
+
+```bash
+sudo systemctl start awesome-postgres-restore-check.service
+sudo journalctl -u awesome-postgres-restore-check.service
+```
+
+Inspect timer state:
+
+```bash
+systemctl list-timers 'awesome-postgres-*'
+```
+
+## Recovery
+
+Copy an encrypted archive and its `.sha256` sidecar to a trusted machine with
+Docker, GNU gzip, and OpenSSL. Verify the checksum, decrypt it, and pipe the SQL
+into a clean PostgreSQL 16.14 database. Use the same OpenSSL parameters as the
+automation: AES-256-CBC, PBKDF2, and 200,000 iterations.

--- a/docs/PRODUCTION_EDGE_PROXY.md
+++ b/docs/PRODUCTION_EDGE_PROXY.md
@@ -1,0 +1,35 @@
+# Production trusted edge proxy
+
+Production uses two nginx layers with different responsibilities:
+
+1. `edge` runs with host networking and owns public port 80. It can see the
+   actual TCP peer, trusts forwarded addresses only from the documented Mikrus
+   proxy range, and overwrites `X-Forwarded-For` with the sanitized client
+   address.
+2. `gateway` is bound only to `127.0.0.1:8080`. It performs hostname and path
+   routing and passes the already-sanitized address to the Spring backends.
+
+This separation is required because Docker's IPv6-to-IPv4 userland proxy makes
+all traffic inside an ordinary bridge container appear to originate at the
+Docker bridge gateway. Without the host-network edge, direct origin callers and
+the Mikrus proxy are indistinguishable to the application gateway.
+
+The trusted range comes from the Mikrus real-IP guidance:
+
+<https://wiki.mikr.us/nginx_ograniczenie_dostepu_po_ip/>
+
+## Verification
+
+Run the regression check:
+
+```bash
+bash scripts/verify-edge-proxy.sh
+```
+
+It sends a deliberately forged `X-Forwarded-For` header through an untrusted
+peer and verifies that the upstream receives the socket address instead of the
+forged value.
+
+Before changing the trusted range, capture the production source address at
+the host boundary and confirm it against current Mikrus documentation. Never
+add a broad trusted range merely to make a forwarded address appear correct.

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.29.7-perl
+    image: nginx:1.31.2-trixie
     restart: unless-stopped
     depends_on:
       - frontend

--- a/nginx/conf.d/app-gateway.conf
+++ b/nginx/conf.d/app-gateway.conf
@@ -9,7 +9,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -22,7 +22,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -33,7 +33,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -44,7 +44,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -55,7 +55,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -98,7 +98,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -116,7 +116,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -129,7 +129,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -140,7 +140,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -151,7 +151,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -162,7 +162,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;
@@ -189,7 +189,7 @@ server {
     proxy_http_version 1.1;
     proxy_set_header Host $http_host;
     proxy_set_header X-Real-IP $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-For $http_x_forwarded_for;
     proxy_set_header X-Forwarded-Host $http_host;
     proxy_set_header X-Forwarded-Port 443;
     proxy_set_header X-Forwarded-Proto https;

--- a/nginx/conf.d/edge-gateway.conf
+++ b/nginx/conf.d/edge-gateway.conf
@@ -1,0 +1,36 @@
+# Mikrus terminates the public HTTPS path before forwarding requests to this
+# IPv6 listener. Its proxy range is documented at:
+# https://wiki.mikr.us/nginx_ograniczenie_dostepu_po_ip/
+#
+# Only that range may supply X-Forwarded-For. Requests arriving directly at
+# the origin keep their socket address, so a caller cannot spoof the address
+# used by backend rate limiting.
+set_real_ip_from 2a01:4f9::/32;
+real_ip_header X-Forwarded-For;
+real_ip_recursive on;
+
+map $http_upgrade $edge_connection_upgrade {
+  default upgrade;
+  '' close;
+}
+
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server ipv6only=on;
+  server_name _;
+
+  client_max_body_size 10m;
+
+  location / {
+    proxy_pass http://127.0.0.1:8080;
+    proxy_http_version 1.1;
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $remote_addr;
+    proxy_set_header X-Forwarded-Host $http_host;
+    proxy_set_header X-Forwarded-Port 443;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $edge_connection_upgrade;
+  }
+}

--- a/scripts/verify-edge-proxy.sh
+++ b/scripts/verify-edge-proxy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+network="awesome-edge-proxy-test-$$"
+edge="awesome-edge-proxy-test-edge-$$"
+echo_server="awesome-edge-proxy-test-echo-$$"
+test_config="$(mktemp)"
+
+cleanup() {
+  docker stop "${edge}" "${echo_server}" >/dev/null 2>&1 || true
+  docker network rm "${network}" >/dev/null 2>&1 || true
+  rm -f -- "${test_config}"
+}
+trap cleanup EXIT
+
+sed 's#http://127.0.0.1:8080#http://echo:80#' \
+  "${repo_root}/nginx/conf.d/edge-gateway.conf" > "${test_config}"
+
+docker network create "${network}" >/dev/null
+docker run --detach --rm \
+  --name "${echo_server}" \
+  --network "${network}" \
+  --network-alias echo \
+  traefik/whoami:v1.11.0 >/dev/null
+docker run --detach --rm \
+  --name "${edge}" \
+  --network "${network}" \
+  --network-alias edge \
+  --volume "${test_config}:/etc/nginx/conf.d/default.conf:ro" \
+  nginx:1.31.2-trixie >/dev/null
+
+response=""
+for _ in $(seq 1 20); do
+  if response="$(
+    docker run --rm --network "${network}" curlimages/curl:8.21.0 \
+      --fail \
+      --silent \
+      --show-error \
+      --header 'X-Forwarded-For: 198.51.100.77' \
+      http://edge/
+  )"; then
+    break
+  fi
+  sleep 1
+done
+
+if [[ -z "${response}" ]]; then
+  echo "Edge proxy did not return a response" >&2
+  exit 1
+fi
+
+if grep -q '198\.51\.100\.77' <<<"${response}"; then
+  echo "Edge proxy passed a spoofed X-Forwarded-For value upstream" >&2
+  exit 1
+fi
+
+if ! grep -qi '^X-Forwarded-For: ' <<<"${response}"; then
+  echo "Edge proxy did not provide a sanitized X-Forwarded-For value" >&2
+  exit 1
+fi
+
+echo "Edge proxy rejected the spoofed client address"


### PR DESCRIPTION
## What changed

- adds encrypted PostgreSQL backup, retention, pre-deploy backup, and isolated restore verification automation
- introduces a host-network trusted edge and binds the internal gateway to `127.0.0.1:8080`
- updates gateway nginx images to `1.31.2-trixie`
- pins both production frontends to `3.7.5`
- adds proxy regression coverage and operational documentation

## Why

This closes the P0 recovery, nginx vulnerability, and forwarded-IP spoofing findings from the production audit.

## Verification

- every Compose file validates
- Ansible deployment syntax passes
- edge spoofing regression passes
- frontend release checks pass independently

Unrelated Bonsai/Ollama working-tree changes are intentionally excluded.