### PR TITLE
Use Bonsai through Docker Model Runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,16 @@ jobs:
     steps:
     - uses: actions/checkout@v7.0.0
     - name: Build and run Docker Compose
-      run: bash ./run-docker-compose.sh
+      run: USE_OLLAMA_MOCK=true bash ./run-docker-compose.sh
+
+  verifyOllamaConfig:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.0
+    - name: Verify Docker Model Runner and mock overrides
+      run: bash ./scripts/verify-ollama-config.sh
+    - name: Test Docker Model Runner adapter
+      run: python3 -m unittest ollama-dmr-adapter/test_adapter.py
 
   runDocker-CI:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -114,12 +114,13 @@ docker compose -f lightweight-docker-compose.yml down
 
 ## Full Profile
 
-Use this when you want the local app plus monitoring, DB, queueing, email testing, consumer, and real Ollama.
+Use this when you want the local app plus monitoring, DB, queueing, email testing,
+consumer, and a real GPU-accelerated local model.
 
 Start it with:
 
 ```bash
-docker compose -f docker-compose.yml up -d
+docker compose up -d
 ```
 
 This local full stack intentionally starts the backend with `docker,demo`, so PostgreSQL-backed demo users, products, and sample orders are available with the same seeded admin credentials as the lightweight profile.
@@ -139,54 +140,61 @@ Other useful full-profile URLs:
 - Keycloak realm: `http://localhost:8082/realms/awesome-testing/.well-known/openid-configuration`
 - Keycloak Admin Console: `http://localhost:8082/admin/` (`admin` / `admin`)
 - consumer metrics: `http://localhost:4002/actuator/prometheus`
-- Ollama: `http://localhost:11434/api/tags`
+- Docker Model Runner status: `docker model status`
 - Postgres: `localhost:5432`
 
 If you need to refresh seeded PostgreSQL demo data after fixture or credential changes:
 
 ```bash
-docker compose -f docker-compose.yml down -v
-docker compose -f docker-compose.yml up -d
+docker compose down -v
+docker compose up -d
 ```
 
-The Ollama container in this profile is expected to expose `qwen3.5:2b` from the published `ollama-qwen35-2b` image.
+The full profile declares Bonsai directly as a Compose model:
 
-### Native Ollama on macOS
+```text
+hf.co/prism-ml/Bonsai-27B-gguf:Q1_0
+```
 
-Docker Desktop on macOS cannot pass the Apple GPU through to a Linux container. For faster local LLM demos on Apple Silicon, run Ollama natively on macOS and keep the rest of the stack in Docker.
+Docker Desktop Model Runner downloads the GGUF once, caches it outside the
+application containers, and serves its Ollama-compatible API with the Metal
+llama.cpp backend on Apple Silicon. This avoids the large custom Ollama image
+and keeps normal startup to one command.
 
-Start native Ollama:
+Compose also builds a small, model-neutral `ollama-dmr-adapter` image locally.
+It normalizes the two wire-format differences needed by the current backend:
+null JSON-Schema members in requests and streamed/stringified tool arguments
+in responses. The adapter does not contain the model; its local image is about
+17 MB, while Docker Model Runner owns the cached GGUF.
+
+Enable Model Runner once on a new Mac:
 
 ```bash
-ollama pull qwen3.5:2b
-OLLAMA_HOST=0.0.0.0:11434 ollama serve
+docker desktop enable model-runner
+docker model status
 ```
 
-In another terminal, start the full stack with the native Ollama override:
+Then normal startup is always:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.native-ollama.yml up -d --remove-orphans
+docker compose up -d
 ```
 
-Or use the helper script:
+To use a different Docker Model Runner or Hugging Face GGUF artifact, override
+`OLLAMA_MODEL` without editing Compose:
 
 ```bash
-./run-docker-compose-native-ollama.sh
+OLLAMA_MODEL=hf.co/unsloth/Qwen3.5-2B-GGUF:Q4_K_M docker compose up -d
 ```
 
-To test another local model, override `OLLAMA_MODEL`; the helper pulls it before starting the stack:
+The model name sent from the frontend must match the selected artifact. The
+frontend model field remains user-editable, so it can be changed at runtime.
 
-```bash
-OLLAMA_MODEL=llama3.2:3b ./run-docker-compose-native-ollama.sh
-```
-
-The override points the backend to `http://host.docker.internal:11434` and disables the containerized Ollama service unless the `docker-ollama` profile is explicitly enabled.
-
-Verify Docker can reach the native Ollama server:
+Verify the Ollama-compatible endpoint from a container:
 
 ```bash
 docker run --rm curlimages/curl:8.13.0 \
-  http://host.docker.internal:11434/api/tags
+  http://model-runner.docker.internal/api/tags
 ```
 
 SSO is enabled in the local `lightweight`, `full`, and `ci` compose profiles. Those profiles all start Keycloak and configure the backend with the local issuer and JWK endpoint. The `server` profile should not use this local training realm by default; production/server SSO needs a real issuer, real redirect URLs, and managed credentials configured deliberately for that deployment.
@@ -212,7 +220,8 @@ flowchart LR
     MQ[ActiveMQ<br/>localhost:8161 and 61616]
     C[Consumer<br/>localhost:4002]
     M[Mailhog<br/>localhost:8025]
-    O[Ollama<br/>localhost:11434]
+    A[Ollama/DMR adapter<br/>local compatibility layer]
+    O[Docker Model Runner<br/>Metal on Apple Silicon]
     P[Prometheus<br/>localhost:9090]
     GR[Grafana<br/>localhost:3000]
     I[InfluxDB<br/>localhost:8086]
@@ -224,7 +233,8 @@ flowchart LR
     B --> MQ
     MQ --> C
     C --> M
-    B --> O
+    B --> A
+    A --> O
     P --> B
     P --> C
     GR --> P

--- a/docker-compose.model-mock.yml
+++ b/docker-compose.model-mock.yml
@@ -1,0 +1,22 @@
+services:
+  backend:
+    environment:
+      OLLAMA_BASE_URL: http://ollama:11434
+    models: !reset []
+    depends_on: !override
+      - activemq
+      - keycloak
+      - ollama
+      - postgres
+
+  ollama-dmr-adapter:
+    profiles:
+      - dmr
+
+  ollama:
+    image: slawekradzyminski/ollama-mock:1.0.5
+    restart: unless-stopped
+    ports:
+      - "11434:11434"
+    networks:
+      - my-private-ntwk

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.4
+    image: slawekradzyminski/frontend:3.7.5
     restart: always
     expose:
       - "80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,12 +21,28 @@ services:
       APP_SSO_JWK_SET_URI: http://keycloak:8080/realms/awesome-testing/protocol/openid-connect/certs
       APP_SSO_AUDIENCE: awesome-testing-frontend
       APP_CORS_ALLOWED_ORIGIN_PATTERNS: http://localhost:8081,http://127.0.0.1:8081,http://host.docker.internal:8081
-      OLLAMA_BASE_URL: http://ollama:11434
+      OLLAMA_BASE_URL: ${OLLAMA_BASE_URL:-http://ollama-dmr-adapter:11434}
+      OLLAMA_MAX_TOOL_CALL_ITERATIONS: ${OLLAMA_MAX_TOOL_CALL_ITERATIONS:-8}
+    models:
+      local_llm:
+        endpoint_var: DMR_MODEL_ENDPOINT
+        model_var: OLLAMA_MODEL
     depends_on:
       - activemq
       - keycloak
-      - ollama
+      - ollama-dmr-adapter
       - postgres
+    networks:
+      - my-private-ntwk
+
+  ollama-dmr-adapter:
+    image: awesome-localstack/ollama-dmr-adapter:local
+    build:
+      context: ./ollama-dmr-adapter
+    restart: unless-stopped
+    environment:
+      UPSTREAM_HOST: model-runner.docker.internal
+      UPSTREAM_PORT: "80"
     networks:
       - my-private-ntwk
 
@@ -179,20 +195,14 @@ services:
     networks:
       - my-private-ntwk
 
-  ollama:
-    image: slawekradzyminski/ollama-qwen35-2b:0.18.3-2
-    restart: unless-stopped
-    ports:
-      - "11434:11434"
-    environment:
-      - OLLAMA_MODELS=/models
-    networks:
-      - my-private-ntwk
-
 volumes:
   influxdb-storage:
   postgres-data:
-  ollama-data:
+
+models:
+  local_llm:
+    model: ${OLLAMA_MODEL:-hf.co/prism-ml/Bonsai-27B-gguf:Q1_0}
+    context_size: 8192
 
 networks:
   my-private-ntwk:

--- a/ollama-dmr-adapter/.dockerignore
+++ b/ollama-dmr-adapter/.dockerignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/ollama-dmr-adapter/Dockerfile
+++ b/ollama-dmr-adapter/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.13-alpine
+
+WORKDIR /app
+COPY adapter.py /app/adapter.py
+
+USER nobody
+EXPOSE 11434
+
+ENTRYPOINT ["python", "/app/adapter.py"]

--- a/ollama-dmr-adapter/adapter.py
+++ b/ollama-dmr-adapter/adapter.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Minimal Ollama-to-Docker-Model-Runner compatibility adapter."""
+
+from __future__ import annotations
+
+import http.client
+import json
+import os
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+
+UPSTREAM_HOST = os.environ.get("UPSTREAM_HOST", "model-runner.docker.internal")
+UPSTREAM_PORT = int(os.environ.get("UPSTREAM_PORT", "80"))
+
+
+def without_nulls(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: without_nulls(item) for key, item in value.items() if item is not None}
+    if isinstance(value, list):
+        return [without_nulls(item) for item in value]
+    return value
+
+
+def normalize_response_line(line: bytes, tool_states: dict[int, dict[str, Any]] | None = None) -> bytes:
+    """Convert DMR's stringified tool arguments to Ollama's object shape."""
+    if tool_states is None:
+        tool_states = {}
+    try:
+        payload = json.loads(line)
+        message = payload.get("message", {})
+        tool_calls = message.get("tool_calls") or []
+        completed_calls = []
+        for position, tool_call in enumerate(tool_calls):
+            function = tool_call.get("function") or {}
+            arguments = function.get("arguments")
+            index = int(function.get("index", position))
+            state = tool_states.setdefault(
+                index,
+                {"id": tool_call.get("id"), "type": tool_call.get("type"), "name": "", "arguments": ""},
+            )
+            state["id"] = tool_call.get("id") or state["id"]
+            state["type"] = tool_call.get("type") or state["type"]
+            if function.get("name") and not state["name"]:
+                state["name"] = function["name"]
+
+            if isinstance(arguments, str):
+                state["arguments"] += arguments
+                try:
+                    decoded_arguments = json.loads(state["arguments"])
+                except json.JSONDecodeError:
+                    continue
+            else:
+                decoded_arguments = arguments
+
+            if isinstance(decoded_arguments, str):
+                decoded_arguments = json.loads(decoded_arguments)
+            if not isinstance(decoded_arguments, dict):
+                continue
+
+            completed_call = {
+                "function": {"name": state["name"], "arguments": decoded_arguments},
+            }
+            if state["id"]:
+                completed_call["id"] = state["id"]
+            if state["type"]:
+                completed_call["type"] = state["type"]
+            completed_calls.append(completed_call)
+            del tool_states[index]
+
+        if tool_calls:
+            if completed_calls:
+                message["tool_calls"] = completed_calls
+            else:
+                message.pop("tool_calls", None)
+        suffix = b"\n" if line.endswith(b"\n") else b""
+        return json.dumps(payload, separators=(",", ":")).encode() + suffix
+    except (AttributeError, json.JSONDecodeError, TypeError):
+        return line
+
+
+class AdapterHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.0"
+
+    def do_GET(self) -> None:  # noqa: N802
+        if self.path == "/healthz":
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"ok\n")
+            return
+        self._proxy(None)
+
+    def do_POST(self) -> None:  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        if self.headers.get_content_type() == "application/json" and body:
+            body = json.dumps(without_nulls(json.loads(body)), separators=(",", ":")).encode()
+        self._proxy(body)
+
+    def _proxy(self, body: bytes | None) -> None:
+        connection = http.client.HTTPConnection(UPSTREAM_HOST, UPSTREAM_PORT, timeout=600)
+        headers = {"Accept": self.headers.get("Accept", "*/*")}
+        if body is not None:
+            headers["Content-Type"] = self.headers.get("Content-Type", "application/json")
+
+        try:
+            connection.request(self.command, self.path, body=body, headers=headers)
+            response = connection.getresponse()
+            self.send_response(response.status)
+            content_type = response.getheader("Content-Type")
+            if content_type:
+                self.send_header("Content-Type", content_type)
+            self.end_headers()
+            tool_states: dict[int, dict[str, Any]] = {}
+            while line := response.readline():
+                self.wfile.write(normalize_response_line(line, tool_states))
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+        finally:
+            connection.close()
+
+    def log_message(self, format_string: str, *args: object) -> None:
+        print(f"{self.address_string()} {format_string % args}", flush=True)
+
+
+if __name__ == "__main__":
+    ThreadingHTTPServer(("0.0.0.0", 11434), AdapterHandler).serve_forever()

--- a/ollama-dmr-adapter/test_adapter.py
+++ b/ollama-dmr-adapter/test_adapter.py
@@ -1,0 +1,75 @@
+import importlib.util
+import json
+import pathlib
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("adapter.py")
+SPEC = importlib.util.spec_from_file_location("adapter", MODULE_PATH)
+adapter = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(adapter)
+
+
+class AdapterTest(unittest.TestCase):
+    def test_removes_nulls_recursively(self) -> None:
+        value = {"required": None, "properties": {"name": {"enum": None, "type": "string"}}}
+        self.assertEqual(
+            {"properties": {"name": {"type": "string"}}},
+            adapter.without_nulls(value),
+        )
+
+    def test_decodes_stringified_tool_arguments(self) -> None:
+        line = json.dumps(
+            {
+                "message": {
+                    "tool_calls": [
+                        {"function": {"name": "list_products", "arguments": '{"limit":25}'}}
+                    ]
+                }
+            }
+        ).encode() + b"\n"
+
+        result = json.loads(adapter.normalize_response_line(line))
+        self.assertEqual(
+            {"limit": 25},
+            result["message"]["tool_calls"][0]["function"]["arguments"],
+        )
+
+    def test_decodes_double_stringified_tool_arguments(self) -> None:
+        arguments = json.dumps(json.dumps({"inStockOnly": True}))
+        line = json.dumps(
+            {"message": {"tool_calls": [{"function": {"arguments": arguments}}]}}
+        ).encode()
+
+        result = json.loads(adapter.normalize_response_line(line))
+        self.assertEqual(
+            {"inStockOnly": True},
+            result["message"]["tool_calls"][0]["function"]["arguments"],
+        )
+
+    def test_joins_streamed_tool_arguments(self) -> None:
+        states = {}
+        first = json.dumps(
+            {"message": {"tool_calls": [{"function": {"index": 0, "name": "list_products", "arguments": "{"}}]}}
+        ).encode() + b"\n"
+        second = json.dumps(
+            {"message": {"tool_calls": [{"function": {"index": 0, "arguments": '\"limit\":25}'}}]}}
+        ).encode() + b"\n"
+
+        first_result = json.loads(adapter.normalize_response_line(first, states))
+        second_result = json.loads(adapter.normalize_response_line(second, states))
+
+        self.assertNotIn("tool_calls", first_result["message"])
+        self.assertEqual(
+            {"limit": 25},
+            second_result["message"]["tool_calls"][0]["function"]["arguments"],
+        )
+        self.assertEqual(
+            "list_products",
+            second_result["message"]["tool_calls"][0]["function"]["name"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/run-docker-compose.sh
+++ b/run-docker-compose.sh
@@ -1,7 +1,35 @@
 #!/bin/bash
 
-# Start the full profile explicitly
-docker compose -f docker-compose.yml up -d
+# Start the full profile explicitly. CI opts into a deterministic mock because
+# hosted runners do not provide Docker Desktop Model Runner.
+COMPOSE_FILES=(-f docker-compose.yml)
+if [ "${USE_OLLAMA_MOCK:-false}" = "true" ]; then
+    COMPOSE_FILES+=(-f docker-compose.model-mock.yml)
+fi
+docker compose "${COMPOSE_FILES[@]}" up -d
+
+if [ "${USE_OLLAMA_MOCK:-false}" = "true" ]; then
+    MODEL_URL="http://localhost:11434/api/generate"
+    MODEL_NAME="Ollama mock"
+    MODEL_CHECK=(curl -fsS -H "Content-Type: application/json" -d '{"model":"qwen3.5:2b","prompt":"Provide a motivational quote","stream":false}' "$MODEL_URL")
+else
+    MODEL_URL="http://model-runner.docker.internal/api/tags"
+    MODEL_NAME="Docker Model Runner"
+    MODEL_CHECK=(docker run --rm curlimages/curl:8.13.0 -fsS "$MODEL_URL")
+fi
+
+echo "Waiting for $MODEL_NAME to start..."
+for attempt in {1..120}; do
+    if "${MODEL_CHECK[@]}" >/dev/null 2>&1; then
+        echo "$MODEL_NAME started successfully."
+        break
+    fi
+    if [ "$attempt" -eq 120 ]; then
+        echo "$MODEL_NAME did not start within 2 minutes. Exiting."
+        exit 1
+    fi
+    sleep 1
+done
 
 # Function to wait for an endpoint to return HTTP 200
 wait_for_http_200() {
@@ -45,7 +73,6 @@ urls=(
     "http://localhost:8161"
     "http://localhost:8025/"
     "http://localhost:4002/actuator/prometheus"
-    "http://localhost:11434/api/tags"
     "http://localhost:8082/realms/awesome-testing/.well-known/openid-configuration"
     "http://localhost:8081/images/applewatch.png"
 )
@@ -57,7 +84,6 @@ names=(
     "Active MQ"
     "Mailhog"
     "Email consumer"
-    "Ollama"
     "Keycloak"
     "Gateway-served product image"
 )

--- a/scripts/verify-ollama-config.sh
+++ b/scripts/verify-ollama-config.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEFAULT_MODEL="hf.co/prism-ml/Bonsai-27B-gguf:Q1_0"
+QWEN_MODEL="hf.co/unsloth/Qwen3.5-2B-GGUF:Q4_K_M"
+MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.5"
+
+default_config="$(docker compose -f docker-compose.yml config)"
+grep -F "model: $DEFAULT_MODEL" <<<"$default_config"
+grep -F "OLLAMA_BASE_URL: http://ollama-dmr-adapter:11434" <<<"$default_config"
+grep -F "model_var: OLLAMA_MODEL" <<<"$default_config"
+grep -F "image: awesome-localstack/ollama-dmr-adapter:local" <<<"$default_config"
+
+qwen_config="$(OLLAMA_MODEL="$QWEN_MODEL" docker compose -f docker-compose.yml config)"
+grep -F "model: $QWEN_MODEL" <<<"$qwen_config"
+
+mock_config="$(docker compose -f docker-compose.yml -f docker-compose.model-mock.yml config)"
+grep -F "OLLAMA_BASE_URL: http://ollama:11434" <<<"$mock_config"
+if grep -F "awesome-localstack/ollama-dmr-adapter:local" <<<"$mock_config"; then
+  echo "DMR adapter must not start with the CI mock profile." >&2
+  exit 1
+fi
+docker compose -f docker-compose.yml -f docker-compose.model-mock.yml config --images \
+  | grep -Fx "$MOCK_IMAGE"
+
+docker compose -f lightweight-docker-compose.yml config --images | grep -Fx "$MOCK_IMAGE"
+docker compose -f docker-compose.server.yml config --images | grep -Fx "$MOCK_IMAGE"
+
+echo "Ollama configuration checks passed."


### PR DESCRIPTION
## Summary
- make Docker Desktop Model Runner the full-profile LLM runtime, with Bonsai Q1 as the default and `OLLAMA_MODEL` overrides
- add a small local DMR/Ollama compatibility adapter for tool schemas and streamed tool arguments
- preserve the existing Qwen mock for CI and contract fixtures

## Verification
- literal `docker compose up -d` starts the complete local stack on Apple Silicon/Metal
- Bonsai generate and two-iteration tool call completed through backend
- adapter unit tests and Compose configuration guard pass
- full mock-profile startup passes; Qwen generate/chat/tool-chat canned contracts pass unchanged

## Existing unrelated contract drift
The local l12 suite is 27/59 against backend:3.7.8 because l12 expects UUID refresh tokens while the image returns opaque tokens. The Ollama mock assertions were verified directly with an authenticated admin token and remain unchanged.