### PR TITLE
Deploy frontend 3.7.6

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.8
+    image: slawekradzyminski/backend:3.7.9
     restart: unless-stopped
     hostname: backend
     logging: *default-logging
@@ -69,7 +69,7 @@ services:
       - my-private-ntwk
 
   aitesters-backend:
-    image: slawekradzyminski/backend:3.7.8
+    image: slawekradzyminski/backend:3.7.9
     restart: unless-stopped
     hostname: aitesters-backend
     logging: *default-logging

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -60,7 +60,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.5
+    image: slawekradzyminski/frontend:3.7.6
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -104,7 +104,7 @@ services:
       - my-private-ntwk
 
   aitesters-frontend:
-    image: slawekradzyminski/frontend:3.7.5
+    image: slawekradzyminski/frontend:3.7.6
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.5
+    image: slawekradzyminski/frontend:3.7.6
     restart: always
     expose:
       - "80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.8
+    image: slawekradzyminski/backend:3.7.9
     restart: always
     expose:
       - "4001"


### PR DESCRIPTION
## Summary
- pin the Mac default profile to frontend 3.7.6
- pin both production frontend services to frontend 3.7.6
- use a fresh immutable tag so production does not retain the older cached 3.7.5 image

## Validation
- all Compose files validate
- Ollama/Bonsai configuration and override checks pass
- Docker Model Runner adapter tests pass
- trusted-edge spoofing regression passes
- multi-platform frontend manifest exists with provenance attestations