### PR TITLE
Fix Bonsai thinking toggle with Model Runner

### DIFF
--- a/ollama-dmr-adapter/adapter.py
+++ b/ollama-dmr-adapter/adapter.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 import http.client
 import json
 import os
+from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
 
 UPSTREAM_HOST = os.environ.get("UPSTREAM_HOST", "model-runner.docker.internal")
 UPSTREAM_PORT = int(os.environ.get("UPSTREAM_PORT", "80"))
+OPENAI_CHAT_PATH = "/engines/llama.cpp/v1/chat/completions"
 
 
 def without_nulls(value: Any) -> Any:
@@ -20,6 +22,179 @@ def without_nulls(value: Any) -> Any:
     if isinstance(value, list):
         return [without_nulls(item) for item in value]
     return value
+
+
+def should_translate_thinking_request(path: str, payload: dict[str, Any]) -> bool:
+    """Use llama.cpp's native switch when the Ollama-compatible API ignores think=false."""
+    return (
+        path in {"/api/generate", "/api/chat"}
+        and payload.get("think") is False
+        and payload.get("raw") is not True
+    )
+
+
+def _openai_tool_call(tool_call: dict[str, Any]) -> dict[str, Any]:
+    function = tool_call.get("function") or {}
+    arguments = function.get("arguments", "{}")
+    if not isinstance(arguments, str):
+        arguments = json.dumps(arguments, separators=(",", ":"))
+
+    result = {
+        "type": tool_call.get("type") or "function",
+        "function": {
+            "name": function.get("name", ""),
+            "arguments": arguments,
+        },
+    }
+    if tool_call.get("id"):
+        result["id"] = tool_call["id"]
+    return result
+
+
+def _openai_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    translated = []
+    pending_tool_ids: dict[str, list[str]] = {}
+
+    for message in messages:
+        role = message.get("role")
+        if role == "tool":
+            tool_name = message.get("tool_name") or message.get("name", "")
+            matching_ids = pending_tool_ids.get(tool_name, [])
+            tool_call_id = message.get("tool_call_id")
+            if not tool_call_id and matching_ids:
+                tool_call_id = matching_ids.pop(0)
+            translated.append(
+                {
+                    "role": "tool",
+                    "content": message.get("content", ""),
+                    "tool_call_id": tool_call_id or tool_name,
+                }
+            )
+            continue
+
+        translated_message = {
+            "role": role,
+            "content": message.get("content", ""),
+        }
+        tool_calls = message.get("tool_calls") or []
+        if tool_calls:
+            translated_calls = [_openai_tool_call(call) for call in tool_calls]
+            translated_message["tool_calls"] = translated_calls
+            for call in translated_calls:
+                function_name = call["function"]["name"]
+                call_id = call.get("id")
+                if function_name and call_id:
+                    pending_tool_ids.setdefault(function_name, []).append(call_id)
+        translated.append(translated_message)
+
+    return translated
+
+
+def translate_ollama_request(path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Translate the subset used by the app to llama.cpp's OpenAI-compatible API."""
+    if path == "/api/generate":
+        messages = []
+        if payload.get("system"):
+            messages.append({"role": "system", "content": payload["system"]})
+        messages.append({"role": "user", "content": payload.get("prompt", "")})
+    else:
+        messages = _openai_messages(payload.get("messages") or [])
+
+    translated: dict[str, Any] = {
+        "model": payload.get("model"),
+        "messages": messages,
+        "stream": payload.get("stream", True),
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+
+    options = payload.get("options") or {}
+    option_names = {
+        "temperature": "temperature",
+        "top_p": "top_p",
+        "stop": "stop",
+        "presence_penalty": "presence_penalty",
+        "frequency_penalty": "frequency_penalty",
+        "num_predict": "max_tokens",
+    }
+    for ollama_name, openai_name in option_names.items():
+        if ollama_name in options:
+            translated[openai_name] = options[ollama_name]
+
+    for name in ("tools", "tool_choice", "logprobs", "top_logprobs"):
+        if name in payload:
+            translated[name] = payload[name]
+
+    return without_nulls(translated)
+
+
+def _created_at(value: Any) -> str:
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, timezone.utc).isoformat().replace("+00:00", "Z")
+    return str(value or "")
+
+
+def normalize_openai_response_line(
+    line: bytes,
+    response_kind: str,
+    request_model: str,
+    tool_states: dict[int, dict[str, Any]] | None = None,
+) -> bytes:
+    """Convert OpenAI SSE/JSON chunks back to the Ollama NDJSON response contract."""
+    stripped = line.strip()
+    if not stripped:
+        return b""
+    if stripped.startswith(b"data:"):
+        stripped = stripped.removeprefix(b"data:").strip()
+    if stripped == b"[DONE]":
+        return b""
+
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return line
+    if "error" in payload:
+        return json.dumps(payload, separators=(",", ":")).encode() + b"\n"
+
+    choices = payload.get("choices") or []
+    if not choices:
+        return b""
+    choice = choices[0]
+    message = choice.get("delta") or choice.get("message") or {}
+    finish_reason = choice.get("finish_reason")
+    done = finish_reason is not None or payload.get("object") == "chat.completion"
+    content = message.get("content")
+    thinking = message.get("reasoning_content") or message.get("reasoning")
+
+    result: dict[str, Any] = {
+        "model": request_model,
+        "created_at": _created_at(payload.get("created")),
+        "done": done,
+    }
+    if response_kind == "generate":
+        result["response"] = content or ""
+        if thinking:
+            result["thinking"] = thinking
+    else:
+        ollama_message: dict[str, Any] = {
+            "role": message.get("role") or "assistant",
+            "content": content or "",
+        }
+        if thinking:
+            ollama_message["thinking"] = thinking
+        if message.get("tool_calls"):
+            ollama_message["tool_calls"] = message["tool_calls"]
+        result["message"] = ollama_message
+
+    usage = payload.get("usage") or {}
+    if usage.get("prompt_tokens") is not None:
+        result["prompt_eval_count"] = usage["prompt_tokens"]
+    if usage.get("completion_tokens") is not None:
+        result["eval_count"] = usage["completion_tokens"]
+
+    normalized = json.dumps(result, separators=(",", ":")).encode() + b"\n"
+    if response_kind == "chat":
+        return normalize_response_line(normalized, tool_states)
+    return normalized
 
 
 def normalize_response_line(line: bytes, tool_states: dict[int, dict[str, Any]] | None = None) -> bytes:
@@ -94,27 +269,50 @@ class AdapterHandler(BaseHTTPRequestHandler):
     def do_POST(self) -> None:  # noqa: N802
         length = int(self.headers.get("Content-Length", "0"))
         body = self.rfile.read(length)
+        upstream_path = self.path
+        response_kind = None
+        request_model = ""
         if self.headers.get_content_type() == "application/json" and body:
-            body = json.dumps(without_nulls(json.loads(body)), separators=(",", ":")).encode()
-        self._proxy(body)
+            payload = without_nulls(json.loads(body))
+            request_model = payload.get("model", "")
+            if should_translate_thinking_request(self.path, payload):
+                response_kind = "generate" if self.path == "/api/generate" else "chat"
+                payload = translate_ollama_request(self.path, payload)
+                upstream_path = OPENAI_CHAT_PATH
+            body = json.dumps(payload, separators=(",", ":")).encode()
+        self._proxy(body, upstream_path, response_kind, request_model)
 
-    def _proxy(self, body: bytes | None) -> None:
+    def _proxy(
+        self,
+        body: bytes | None,
+        upstream_path: str | None = None,
+        response_kind: str | None = None,
+        request_model: str = "",
+    ) -> None:
         connection = http.client.HTTPConnection(UPSTREAM_HOST, UPSTREAM_PORT, timeout=600)
         headers = {"Accept": self.headers.get("Accept", "*/*")}
         if body is not None:
             headers["Content-Type"] = self.headers.get("Content-Type", "application/json")
 
         try:
-            connection.request(self.command, self.path, body=body, headers=headers)
+            connection.request(self.command, upstream_path or self.path, body=body, headers=headers)
             response = connection.getresponse()
             self.send_response(response.status)
-            content_type = response.getheader("Content-Type")
+            content_type = "application/x-ndjson" if response_kind else response.getheader("Content-Type")
             if content_type:
                 self.send_header("Content-Type", content_type)
             self.end_headers()
             tool_states: dict[int, dict[str, Any]] = {}
             while line := response.readline():
-                self.wfile.write(normalize_response_line(line, tool_states))
+                if response_kind:
+                    normalized = normalize_openai_response_line(
+                        line, response_kind, request_model, tool_states
+                    )
+                else:
+                    normalized = normalize_response_line(line, tool_states)
+                if not normalized:
+                    continue
+                self.wfile.write(normalized)
                 self.wfile.flush()
         except (BrokenPipeError, ConnectionResetError):
             pass

--- a/ollama-dmr-adapter/test_adapter.py
+++ b/ollama-dmr-adapter/test_adapter.py
@@ -70,6 +70,124 @@ class AdapterTest(unittest.TestCase):
             second_result["message"]["tool_calls"][0]["function"]["name"],
         )
 
+    def test_translates_generate_think_false_to_llama_cpp_switch(self) -> None:
+        request = adapter.translate_ollama_request(
+            "/api/generate",
+            {
+                "model": "bonsai",
+                "prompt": "Reply with OK",
+                "stream": True,
+                "think": False,
+                "options": {"temperature": 0.2, "num_predict": 10},
+            },
+        )
+
+        self.assertEqual(
+            {"enable_thinking": False},
+            request["chat_template_kwargs"],
+        )
+        self.assertEqual(
+            [{"role": "user", "content": "Reply with OK"}],
+            request["messages"],
+        )
+        self.assertEqual(0.2, request["temperature"])
+        self.assertEqual(10, request["max_tokens"])
+
+    def test_does_not_translate_raw_learning_request(self) -> None:
+        self.assertFalse(
+            adapter.should_translate_thinking_request(
+                "/api/generate", {"think": False, "raw": True}
+            )
+        )
+
+    def test_keeps_thinking_enabled_request_on_ollama_endpoint(self) -> None:
+        self.assertFalse(
+            adapter.should_translate_thinking_request(
+                "/api/generate", {"think": True}
+            )
+        )
+
+    def test_translates_tool_history_to_openai_contract(self) -> None:
+        request = adapter.translate_ollama_request(
+            "/api/chat",
+            {
+                "model": "bonsai",
+                "think": False,
+                "messages": [
+                    {"role": "user", "content": "List products"},
+                    {
+                        "role": "assistant",
+                        "content": "",
+                        "tool_calls": [
+                            {
+                                "id": "call-1",
+                                "function": {
+                                    "name": "list_products",
+                                    "arguments": {"limit": 2},
+                                },
+                            }
+                        ],
+                    },
+                    {
+                        "role": "tool",
+                        "tool_name": "list_products",
+                        "content": '{"products":[]}',
+                    },
+                ],
+            },
+        )
+
+        self.assertEqual(
+            '{"limit":2}',
+            request["messages"][1]["tool_calls"][0]["function"]["arguments"],
+        )
+        self.assertEqual("call-1", request["messages"][2]["tool_call_id"])
+        self.assertNotIn("tool_name", request["messages"][2])
+
+    def test_converts_openai_generate_chunk_to_ollama(self) -> None:
+        line = (
+            b'data: {"choices":[{"finish_reason":null,"delta":{"content":"OK"}}],'
+            b'"created":123,"object":"chat.completion.chunk"}\n'
+        )
+
+        result = json.loads(
+            adapter.normalize_openai_response_line(line, "generate", "bonsai")
+        )
+
+        self.assertEqual("bonsai", result["model"])
+        self.assertEqual("OK", result["response"])
+        self.assertFalse(result["done"])
+        self.assertNotIn("thinking", result)
+
+    def test_converts_streamed_openai_tool_arguments_to_ollama_object(self) -> None:
+        states = {}
+        first = (
+            b'data: {"choices":[{"finish_reason":null,"delta":{"tool_calls":['
+            b'{"index":0,"id":"call-1","type":"function","function":'
+            b'{"name":"list_products","arguments":"{"}}]}}],"created":123}\n'
+        )
+        second = (
+            b'data: {"choices":[{"finish_reason":null,"delta":{"tool_calls":['
+            b'{"index":0,"function":{"arguments":"\\\"limit\\\":2}"}}]}}],'
+            b'"created":123}\n'
+        )
+
+        first_result = json.loads(
+            adapter.normalize_openai_response_line(first, "chat", "bonsai", states)
+        )
+        second_result = json.loads(
+            adapter.normalize_openai_response_line(second, "chat", "bonsai", states)
+        )
+
+        self.assertNotIn("tool_calls", first_result["message"])
+        self.assertEqual(
+            {"limit": 2},
+            second_result["message"]["tool_calls"][0]["function"]["arguments"],
+        )
+        self.assertEqual(
+            "call-1", second_result["message"]["tool_calls"][0]["id"]
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## What changed

- translate Ollama requests with think=false to Docker Model Runner’s llama.cpp OpenAI endpoint
- map enable_thinking=false while preserving the existing Ollama NDJSON response contract
- preserve thinking-enabled behavior and streamed tool calls
- add focused adapter coverage for generation, chat history, and tool arguments

## Why

Docker Model Runner’s Ollama-compatible endpoint ignored think=false for Bonsai, so reasoning tokens were still generated and displayed even when the UI toggle was disabled.

## Validation

- 10 adapter unit tests
- Compose and mock-profile configuration checks
- browser E2E for Generate with thinking off/on
- browser E2E for Chat + Tools
- GitHub CI green