### PR TITLE
Document AI Lab authentication requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Docker orchestration for the training stack built from separate backend, frontend, and consumer repositories.
 
-The standalone AI Learning Lab is served by its own container at `/learn/`. The gateway keeps the existing public URL while isolating the guided courses, exercises, diagrams, and recorded lesson routes from the commerce frontend.
+The standalone AI Learning Lab is served by its own container at `/learn/`. The gateway keeps the existing public URL while isolating the guided courses, exercises, diagrams, and recorded lesson routes from the commerce frontend. Lab course content requires a valid application session; a signed-out browser is sent to `/login` and returned to its requested Lab route after authentication.
 
 This README is organized by the three main profiles:
 
@@ -35,7 +35,7 @@ docker compose -f lightweight-docker-compose.yml up -d
 Main app URL:
 
 - `http://localhost:8081/login`
-- AI Learning Lab: `http://localhost:8081/learn/`
+- AI Learning Lab after sign-in: `http://localhost:8081/learn/`
 
 Other useful lightweight URLs:
 
@@ -102,7 +102,7 @@ Expected:
 
 - all lightweight containers are `Up`
 - login page loads
-- the standalone AI Learning Lab responds through the same gateway
+- the standalone AI Learning Lab shell responds through the same gateway; authenticated course access must be checked in a browser after sign-in
 - Swagger and OpenAPI respond with `200`
 - product image responds with `200`
 - the mocked model path responds with the same `qwen3.5:2b` default used across the migration
@@ -175,7 +175,7 @@ This local full stack intentionally starts the backend with `docker,demo`, so Po
 Main app URL:
 
 - `http://localhost:8081/login`
-- AI Learning Lab: `http://localhost:8081/learn/`
+- AI Learning Lab after sign-in: `http://localhost:8081/learn/`
 
 Other useful full-profile URLs:
 
@@ -370,7 +370,7 @@ Main public URLs:
 
 Other stable playground URLs:
 
-- AI Learning Lab: `https://awesome.byst.re/learn/`
+- AI Learning Lab after sign-in: `https://awesome.byst.re/learn/`
 - recorded Attention lesson: `https://awesome.byst.re/learn/how-llm-works/course/attention`
 - Swagger UI: `https://awesome.byst.re/swagger-ui/index.html`
 - OpenAPI JSON: `https://awesome.byst.re/v3/api-docs`
@@ -450,7 +450,7 @@ curl -i https://aitesters.byst.re/api/v1/local/email/outbox
 Expected:
 
 - `awesome.byst.re/login` returns `200`
-- the AI Lab shell and recorded Attention deep route return `200`
+- the AI Lab shell and recorded Attention deep route return `200`; this curl check does not verify the application session required to view course content
 - `awesome.byst.re/v3/api-docs` returns `200`
 - `awesome.byst.re/images/iphone.png` returns `200`
 - `awesome.byst.re/mailpit/api/v1/messages` returns `404`

--- a/docs/PROFILE_URLS.md
+++ b/docs/PROFILE_URLS.md
@@ -32,6 +32,8 @@ That gateway is the intended public surface for:
 - static images under `/images/...`
 - AI Learning Lab under `/learn/...`
 
+AI Learning Lab course content requires a valid application session in every profile. A signed-out browser is redirected to `/login` with the requested Lab path preserved in `returnTo`, then returned to that path after successful login. Raw `curl` checks below only prove that the static Lab shell is reachable through the gateway.
+
 ## Mermaid Diagrams
 
 ### Lightweight
@@ -110,7 +112,7 @@ docker compose -f docker-compose.yml down
 Recommended app URLs:
 
 - frontend: `http://localhost:8081/login`
-- AI Learning Lab: `http://localhost:8081/learn/`
+- AI Learning Lab after sign-in: `http://localhost:8081/learn/`
 - Swagger UI: `http://localhost:8081/swagger-ui/index.html`
 - OpenAPI JSON: `http://localhost:8081/v3/api-docs`
 - sign in API: `http://localhost:8081/api/v1/users/signin`
@@ -163,7 +165,7 @@ docker compose -f lightweight-docker-compose.yml down
 Recommended app URLs:
 
 - frontend: `http://localhost:8081/login`
-- AI Learning Lab: `http://localhost:8081/learn/`
+- AI Learning Lab after sign-in: `http://localhost:8081/learn/`
 - Swagger UI: `http://localhost:8081/swagger-ui/index.html`
 - OpenAPI JSON: `http://localhost:8081/v3/api-docs`
 - sign in API: `http://localhost:8081/api/v1/users/signin`
@@ -244,7 +246,7 @@ Recommended public URLs:
 Stable public playground:
 
 - frontend: `https://awesome.byst.re/login`
-- AI Learning Lab: `https://awesome.byst.re/learn/`
+- AI Learning Lab after sign-in: `https://awesome.byst.re/learn/`
 - recorded Attention lesson: `https://awesome.byst.re/learn/how-llm-works/course/attention`
 - Swagger UI: `https://awesome.byst.re/swagger-ui/index.html`
 - OpenAPI JSON: `https://awesome.byst.re/v3/api-docs`
@@ -383,7 +385,7 @@ Expected:
 
 - all services are `Up`
 - `login` returns `200`
-- AI Learning Lab returns `200`
+- AI Learning Lab shell returns `200`; verify protected course access separately in an authenticated browser
 - `v3/api-docs` returns `200`
 - image request returns `200`
 - mock LLM generate request returns `200`
@@ -406,7 +408,7 @@ curl -i https://aitesters.byst.re/api/v1/local/email/outbox
 Expected:
 
 - `awesome.byst.re/login` returns `200`
-- the AI Lab shell and recorded Attention route return `200`
+- the AI Lab shell and recorded Attention route return `200`; verify protected course access separately in an authenticated browser
 - `awesome.byst.re/v3/api-docs` returns `200`
 - `awesome.byst.re/images/iphone.png` returns `200`
 - `awesome.byst.re/mailpit/api/v1/messages` returns `404`

--- a/docs/STUDENT_GUIDE.md
+++ b/docs/STUDENT_GUIDE.md
@@ -24,7 +24,7 @@ Treat this as a single local web app served through one URL:
 Use that URL for:
 
 - frontend pages
-- AI Learning Lab pages under `/learn/`
+- authenticated AI Learning Lab pages under `/learn/`
 - backend API
 - Swagger UI
 - OpenAPI docs
@@ -91,7 +91,7 @@ Main application URL:
 Useful lightweight URLs:
 
 - frontend login: `http://localhost:8081/login`
-- AI Learning Lab: `http://localhost:8081/learn/`
+- AI Learning Lab after sign-in: `http://localhost:8081/learn/`
 - Swagger UI: `http://localhost:8081/swagger-ui/index.html`
 - OpenAPI JSON: `http://localhost:8081/v3/api-docs`
 - sample image through gateway: `http://localhost:8081/images/iphone.png`
@@ -114,6 +114,8 @@ Keycloak SSO login:
 
 For the full SSO flow and the difference between password login and SSO, see [SSO_FLOW.md](SSO_FLOW.md).
 
+The AI Learning Lab requires a valid application session. If you open `/learn/` or a deep lesson URL while signed out, the Lab sends the browser to `/login` with a `returnTo` parameter. After a successful application-password or SSO login, the frontend returns you to the requested Lab route.
+
 For everyday work, prefer `8081`.
 
 ## Verification Checklist
@@ -132,6 +134,8 @@ Expected:
 - styling is present
 - images load
 
+Sign in with one of the application-password or Keycloak SSO training users listed above before continuing.
+
 ### 2. AI Learning Lab Loads
 
 Open:
@@ -142,6 +146,7 @@ Expected:
 
 - the AI Learning Lab course shell loads
 - a deep lesson URL can be reloaded without a `404`
+- signing out and opening the same URL redirects to `/login` while preserving the Lab route in `returnTo`
 
 The lightweight Lab build is guided-only and does not expose live runtime controls. The mock is suitable for deterministic legacy LLM demonstrations, but it does not provide real embeddings or next-token log probabilities.
 
@@ -213,6 +218,8 @@ curl -i -X POST http://localhost:11434/api/generate \
   -H 'Content-Type: application/json' \
   -d '{"model":"qwen3.5:2b","prompt":"hello"}'
 ```
+
+These `curl` requests verify container and gateway availability only. A `200` from `/learn/` means the static Lab application shell is reachable; it does not create an authenticated browser session or prove that protected course content is visible. Complete steps 1 and 2 in a browser to verify authenticated Lab access.
 
 ## How To Read Failures
 


### PR DESCRIPTION
## What changed

- state that AI Learning Lab course content requires an authenticated application session
- document the login returnTo behavior for root and deep Lab routes
- distinguish static shell curl checks from authenticated browser verification
- align the student guide, README, and profile URL guide

## Why

The existing student instructions could imply that opening /learn/ without signing in was sufficient. The Lab application actually redirects signed-out browser users to login and returns them to the requested course route afterward.

## Validation

- git diff --check
- reviewed all three documentation diffs
- no Compose files changed