### PR TITLE
Automate first-party image compatibility checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,13 @@ jobs:
     - name: Test Docker Model Runner adapter
       run: python3 -m unittest ollama-dmr-adapter/test_adapter.py
 
+  verifyReleaseImages:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.0
+    - name: Verify immutable first-party image set
+      run: python3 scripts/verify-release-images.py
+
   runDocker-Jenkins:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/verify-release-images.yml
+++ b/.github/workflows/verify-release-images.yml
@@ -1,0 +1,19 @@
+name: Verify published release images
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '17 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: docker/setup-buildx-action@v4.2.0
+      - name: Verify immutable pins and multi-platform manifests
+        run: python3 scripts/verify-release-images.py --remote

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome LocalStack
 
-Docker orchestration for the training stack built from separate backend, frontend, and consumer repositories.
+Docker orchestration for the training stack built from separate backend, frontend, AI Learning Lab, JMS consumer, and model-mock repositories.
 
 The standalone AI Learning Lab is served by its own container at `/learn/`. The gateway keeps the existing public URL while isolating the guided courses, exercises, diagrams, and recorded lesson routes from the commerce frontend. Lab course content requires a valid application session; a signed-out browser is sent to `/login` and returned to its requested Lab route after authentication.
 
@@ -16,7 +16,7 @@ For classroom or workshop use focused on the lightweight stack, see [docs/STUDEN
 
 For the local SSO flow, standard-login comparison, and local credentials, see [docs/SSO_FLOW.md](docs/SSO_FLOW.md).
 
-For release gates, immutable image selection, recorded-course compatibility, and rollback, see [docs/AI_LAB_RELEASE.md](docs/AI_LAB_RELEASE.md).
+For repository-owned image publishing and the complete five-image compatibility set, see [docs/CONTAINER_RELEASES.md](docs/CONTAINER_RELEASES.md). For AI Lab-specific release gates, recorded-course compatibility, and rollback, see [docs/AI_LAB_RELEASE.md](docs/AI_LAB_RELEASE.md).
 
 Each main compose file now has its own fixed Compose project name. That means switching between `lightweight`, `full`, and `server` should no longer produce normal orphan warnings just because the profiles define different services.
 
@@ -503,6 +503,7 @@ Across the main profiles, the gateway serves:
 - [test-secure-backend](https://github.com/slawekradzyminski/test-secure-backend)
 - [vite-react-frontend](https://github.com/slawekradzyminski/vite-react-frontend)
 - [jms-email-consumer](https://github.com/slawekradzyminski/jms-email-consumer)
+- [ollama-mock](https://github.com/slawekradzyminski/ollama-mock)
 
 ## Troubleshooting
 

--- a/docker-compose.model-mock.yml
+++ b/docker-compose.model-mock.yml
@@ -14,7 +14,7 @@ services:
       - dmr
 
   ollama:
-    image: slawekradzyminski/ollama-mock:1.0.5
+    image: slawekradzyminski/ollama-mock:1.0.5@sha256:2a1af2cbe85a838a6ce1febe00cac8f8bd63cc73f367468dc8c82772f2038e89
     restart: unless-stopped
     ports:
       - "11434:11434"

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -252,7 +252,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.3
+    image: slawekradzyminski/consumer:3.3.3@sha256:60d6dc40846c2437392c953d89c71bcd7fa5c63729bae9d887cc0501fac4d55f
     restart: unless-stopped
     logging: *default-logging
     env_file:
@@ -275,7 +275,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.5
+    image: slawekradzyminski/ollama-mock:1.0.5@sha256:2a1af2cbe85a838a6ce1febe00cac8f8bd63cc73f367468dc8c82772f2038e89
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.3
+    image: slawekradzyminski/consumer:3.3.3@sha256:60d6dc40846c2437392c953d89c71bcd7fa5c63729bae9d887cc0501fac4d55f
     restart: always
     ports:
       - "4002:4002"

--- a/docs/AI_LAB_RELEASE.md
+++ b/docs/AI_LAB_RELEASE.md
@@ -62,13 +62,15 @@ The legacy `LLM` navigation entry should remain for now. It exercises existing g
 
 ## Immutable image and version strategy
 
-Every production release is a three-repository compatibility set, even when only one image changed. The initial standalone Lab release uses:
+Every production release selects a five-image first-party compatibility set, even when only one image changed. Application repositories own image publication; Awesome LocalStack owns the reviewed combination. The current standalone Lab release uses:
 
 | Component | Immutable release reference |
 | --- | --- |
 | backend | `slawekradzyminski/backend:3.7.10@sha256:2706213591b4cd94fcbb6f295ace9c5da6c55acca08fd2f7c63666803c6e9cd9` |
 | primary frontend | `slawekradzyminski/frontend:3.7.7@sha256:a2a6f65f8c94aba11e071374bc325533c746757bd6ad6bbe0924e19e93c21627` |
 | AI Lab | `slawekradzyminski/ai-learning-lab:0.1.0@sha256:b11d8a77e11b207f77d7cd9b506635f647cb3951d7eeb97ca5dafddce86b22dc` |
+| JMS consumer | `slawekradzyminski/consumer:3.3.3@sha256:60d6dc40846c2437392c953d89c71bcd7fa5c63729bae9d887cc0501fac4d55f` |
+| Ollama mock | `slawekradzyminski/ollama-mock:1.0.5@sha256:2a1af2cbe85a838a6ce1febe00cac8f8bd63cc73f367468dc8c82772f2038e89` |
 
 These are registry-published multi-platform manifests. Do not deploy `latest`, a local-only tag, or a tag before its manifest can be pulled on the server architecture. A later release must replace the complete compatibility set intentionally and record its new digests.
 
@@ -85,7 +87,11 @@ Before changing Compose references, verify each artifact:
 docker buildx imagetools inspect slawekradzyminski/ai-learning-lab:<release-tag>
 docker buildx imagetools inspect slawekradzyminski/frontend:<release-tag>
 docker buildx imagetools inspect slawekradzyminski/backend:<release-tag>
+docker buildx imagetools inspect slawekradzyminski/consumer:<release-tag>
+docker buildx imagetools inspect slawekradzyminski/ollama-mock:<release-tag>
 ```
+
+Run `python3 scripts/verify-release-images.py --remote` to check the complete reviewed set. The general repository-owned publishing contract is documented in [CONTAINER_RELEASES.md](CONTAINER_RELEASES.md).
 
 Record the selected tags, digests, Git commits, and course-test run in the release or pull-request description. The Compose file remains the reviewable source of the production compatibility set; `AI_LAB_IMAGE` is useful for candidate smoke tests, but production should converge to the reviewed immutable reference.
 
@@ -105,8 +111,8 @@ Keep course essays, diagrams, slide data, tests, and implementation plans in the
 
 ## Pre-deployment gates
 
-1. Merge green commits to the default branch in the backend, frontend, and AI Lab repositories.
-2. Publish the three candidate images and verify their registry manifests and digests.
+1. Merge green commits to the default branch in every changed first-party application repository.
+2. Publish the changed candidate images and verify the complete five-image registry set and digests.
 3. Update only the intended production image references in `docker-compose.server.yml`.
 4. Validate every Compose combination and nginx configuration.
 5. Run the adapter, inspector, and cross-repository gateway tests.

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -1,0 +1,68 @@
+# First-party container release automation
+
+Awesome LocalStack consumes application images but does not build another repository's source for release. Each source repository owns its tests, version, Dockerfile, multi-platform build, SBOM, provenance, and registry publication. This repository owns the tested compatibility set, immutable Compose references, profile verification, deployment, and rollback.
+
+## Repository ownership
+
+| Source repository | Docker Hub image | Release gate owned by the repository |
+| --- | --- | --- |
+| `test-secure-backend` | `slawekradzyminski/backend` | Maven verification, integration tests, Docker smoke |
+| `vite-react-frontend` | `slawekradzyminski/frontend` | unit tests, production build, course-compatible browser tests, Docker smoke |
+| `ai-learning-lab` | `slawekradzyminski/ai-learning-lab` | unit tests, extraction audit, course browser suite, Docker smoke |
+| `ollama-mock` | `slawekradzyminski/ollama-mock` | API contract tests and container smoke |
+| `jms-email-consumer` | `slawekradzyminski/consumer` | Maven tests and Artemis-to-Mailpit integration smoke |
+
+The same build is also published under the source repository name in GitHub Container Registry. Docker Hub remains the deployment registry during the migration because existing Compose releases already use those names. Do not assume two registries have the same manifest digest; record and pin the digest resolved from the registry used by Compose.
+
+## Workflow contract
+
+Normal pushes and pull requests run verification without publishing. A semantic version Git tag, or an explicit manual candidate invocation, runs the same release gates before building `linux/amd64` and `linux/arm64`. A release workflow must:
+
+1. validate the requested image version against the Maven or npm project version;
+2. test the exact tagged source;
+3. authenticate to GHCR with `GITHUB_TOKEN`;
+4. authenticate to Docker Hub with `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets;
+5. publish semantic-version, commit-SHA, and stable `latest` tags where appropriate;
+6. attach OCI source/revision labels, SBOM, and provenance;
+7. report the immutable manifest digest in the workflow summary.
+
+The Docker Hub token should be scoped to repository image writes and stored separately in every source repository. Do not copy a personal password into Actions. GHCR packages intended for anonymous production pulls must be public before Compose switches to them.
+
+## GitHub Actions runtime baseline
+
+The workflows use action generations whose JavaScript entrypoints target Node.js 24:
+
+- `actions/checkout@v7.0.0`
+- `actions/setup-node@v7.0.0`
+- `actions/setup-java@v5.6.0`
+- `docker/setup-qemu-action@v4.2.0`
+- `docker/setup-buildx-action@v4.2.0`
+- `docker/login-action@v4.4.0`
+- `docker/metadata-action@v6.2.0`
+- `docker/build-push-action@v7.3.0`
+
+Dependabot monitors the `github-actions` ecosystem in every source repository. Review updates as ordinary supply-chain changes; do not suppress runner deprecation warnings by relying on GitHub's temporary forced runtime migration.
+
+## LocalStack compatibility gate
+
+The production compatibility set is the five first-party services above. `scripts/verify-release-images.py` checks that:
+
+- each production service uses a `tag@sha256` reference;
+- the full, lightweight, model-mock, and server profiles agree on shared mock and consumer releases;
+- the AI Lab release runbook records the exact selected references;
+- with `--remote`, every manifest exists and contains both `linux/amd64` and `linux/arm64`.
+
+Static pin verification runs in normal LocalStack CI. `.github/workflows/verify-release-images.yml` performs the registry check weekly and on manual request.
+
+## Release sequence
+
+1. Merge a green source change to that repository's default branch.
+2. Set the Maven or npm version intended for release and merge its verification change.
+3. Create the matching signed or annotated `vX.Y.Z` tag, or run an explicit candidate from the intended commit.
+4. Wait for both registry publications and copy the Docker Hub manifest digest from the workflow summary or `docker buildx imagetools inspect`.
+5. Update the relevant `tag@sha256` references in the LocalStack profiles and the compatibility table.
+6. Run all Compose configuration checks and `python3 scripts/verify-release-images.py --remote`.
+7. Run the affected direct-service, gateway, lightweight, full, and recorded-course gates.
+8. Merge the LocalStack release PR, create an encrypted production backup when stateful services are affected, and deploy through Ansible.
+
+An application release does not require rebuilding unchanged applications. It does require retaining their known-good immutable references in the reviewed compatibility set.

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -110,7 +110,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.5
+    image: slawekradzyminski/ollama-mock:1.0.5@sha256:2a1af2cbe85a838a6ce1febe00cac8f8bd63cc73f367468dc8c82772f2038e89
     restart: always
     ports:
       - "11434:11434"

--- a/scripts/verify-ollama-config.sh
+++ b/scripts/verify-ollama-config.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DEFAULT_MODEL="hf.co/prism-ml/Bonsai-27B-gguf:Q1_0"
 QWEN_MODEL="hf.co/unsloth/Qwen3.5-2B-GGUF:Q4_K_M"
-MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.5"
+MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.5@sha256:2a1af2cbe85a838a6ce1febe00cac8f8bd63cc73f367468dc8c82772f2038e89"
 
 default_config="$(OLLAMA_BASE_URL=http://ollama:11434 docker compose -f docker-compose.yml config)"
 grep -F "name: awesome-full-native" <<<"$default_config"

--- a/scripts/verify-release-images.py
+++ b/scripts/verify-release-images.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Verify the first-party production image compatibility set."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PINNED_IMAGE = re.compile(r"^[^@\s]+:[^@\s]+@sha256:[0-9a-f]{64}$")
+PRODUCTION_SERVICES = (
+    "backend",
+    "frontend",
+    "ai-learning-lab",
+    "consumer",
+    "ollama-mock",
+)
+
+
+def compose_images(*files: str) -> dict[str, str]:
+    command = ["docker", "compose"]
+    for filename in files:
+        command.extend(("-f", filename))
+    command.extend(("config", "--format", "json"))
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    services = json.loads(result.stdout)["services"]
+    return {name: service.get("image", "") for name, service in services.items()}
+
+
+def require(condition: bool, message: str, failures: list[str]) -> None:
+    if not condition:
+        failures.append(message)
+
+
+def verify_remote(image: str, failures: list[str]) -> None:
+    result = subprocess.run(
+        ["docker", "buildx", "imagetools", "inspect", image],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        failures.append(f"Cannot inspect {image}: {result.stderr.strip()}")
+        return
+
+    for platform in ("linux/amd64", "linux/arm64"):
+        require(
+            f"Platform:    {platform}" in result.stdout,
+            f"{image} does not publish {platform}",
+            failures,
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--remote",
+        action="store_true",
+        help="inspect registry manifests and require amd64 plus arm64",
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    server = compose_images("docker-compose.server.yml")
+    full = compose_images("docker-compose.yml")
+    lightweight = compose_images("lightweight-docker-compose.yml")
+    model_mock = compose_images("docker-compose.yml", "docker-compose.model-mock.yml")
+
+    release_images: dict[str, str] = {}
+    for service in PRODUCTION_SERVICES:
+        image = server.get(service, "")
+        require(bool(image), f"server profile is missing {service}", failures)
+        require(
+            bool(PINNED_IMAGE.fullmatch(image)),
+            f"server service {service} must use an immutable tag@sha256 reference: {image}",
+            failures,
+        )
+        release_images[service] = image
+
+    require(
+        full.get("consumer") == release_images["consumer"],
+        "full and server profiles must use the same consumer release",
+        failures,
+    )
+    require(
+        lightweight.get("ollama-mock") == release_images["ollama-mock"],
+        "lightweight and server profiles must use the same Ollama mock release",
+        failures,
+    )
+    require(
+        model_mock.get("ollama") == release_images["ollama-mock"],
+        "the model-mock override must use the production Ollama mock release",
+        failures,
+    )
+
+    runbook = (ROOT / "docs" / "AI_LAB_RELEASE.md").read_text()
+    for service, image in release_images.items():
+        require(
+            image in runbook,
+            f"release runbook does not record the {service} image {image}",
+            failures,
+        )
+
+    if args.remote:
+        for image in sorted(set(release_images.values())):
+            verify_remote(image, failures)
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+
+    mode = "local pins and remote manifests" if args.remote else "local pins"
+    print(f"Verified {mode} for {len(release_images)} first-party images")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- expand the reviewed compatibility set to backend, frontend, AI Lab, JMS consumer, and Ollama mock
- pin the current consumer and mock images to their published immutable multi-platform digests
- add static and scheduled remote manifest verification
- document repository-owned publishing, required secrets, deployment sequencing, and rollback boundaries
- keep profile-specific mock checks synchronized with the immutable references

## Why

The consumer and mock were still deployed from mutable Docker Hub tags and had no stack-level manifest gate. This makes the five first-party images reviewable and reproducible without changing the image contents currently deployed.

## Validation

- all modified Compose files pass `docker compose config --quiet`
- five local pins and all five remote amd64/arm64 manifests verified
- Ollama and AI Lab profile checks pass
- 12 DMR adapter tests pass
- all workflows pass actionlint