### PR TITLE
Document lightweight Lab login behavior

### DIFF
--- a/docs/PROFILE_URLS.md
+++ b/docs/PROFILE_URLS.md
@@ -32,7 +32,7 @@ That gateway is the intended public surface for:
 - static images under `/images/...`
 - AI Learning Lab under `/learn/...`
 
-AI Learning Lab course content requires a valid application session in every profile. A signed-out browser is redirected to `/login` with the requested Lab path preserved in `returnTo`, then returned to that path after successful login. Raw `curl` checks below only prove that the static Lab shell is reachable through the gateway.
+AI Learning Lab course content requires a valid application session in every profile. A signed-out browser is redirected to `/login` with the requested Lab path preserved in `returnTo`. The current full-local and server frontends return to that path after successful login. The lightweight profile intentionally keeps the recorded-course `3.6.16` frontend, which lands on `/` after login; reopen the requested Lab URL to continue. Raw `curl` checks below only prove that the static Lab shell is reachable through the gateway.
 
 ## Mermaid Diagrams
 

--- a/docs/STUDENT_GUIDE.md
+++ b/docs/STUDENT_GUIDE.md
@@ -114,7 +114,7 @@ Keycloak SSO login:
 
 For the full SSO flow and the difference between password login and SSO, see [SSO_FLOW.md](SSO_FLOW.md).
 
-The AI Learning Lab requires a valid application session. If you open `/learn/` or a deep lesson URL while signed out, the Lab sends the browser to `/login` with a `returnTo` parameter. After a successful application-password or SSO login, the frontend returns you to the requested Lab route.
+The AI Learning Lab requires a valid application session. If you open `/learn/` or a deep lesson URL while signed out, the Lab sends the browser to `/login` with a `returnTo` parameter. The full-local and server frontends return you to the requested Lab route after a successful application-password or SSO login. The lightweight profile intentionally retains the recorded-course `3.6.16` frontend; after signing in there, reopen the requested Lab route from the address bar.
 
 For everyday work, prefer `8081`.
 


### PR DESCRIPTION
The release E2E pass confirmed that the intentionally frozen lightweight frontend 3.6.16 redirects anonymous Lab requests to login but lands at the application root after sign-in. Full-local and server frontends preserve the requested deep Lab route. This documentation-only correction keeps the student and profile guides aligned with the recorded-course compatibility choice; no Compose pin or runtime changes are included.