### PR TITLE
Enable AI Lab in the lightweight profile

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,38 @@ jobs:
     - name: Verify immutable first-party image set
       run: python3 scripts/verify-release-images.py
 
+  verifyLightweight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v7.0.0
+    - name: Run published lightweight compatibility set
+      shell: bash
+      run: |
+        set -Eeuo pipefail
+        cleanup() {
+          result=$?
+          if [[ $result -ne 0 ]]; then
+            docker compose -f lightweight-docker-compose.yml ps --all
+            docker compose -f lightweight-docker-compose.yml logs --no-color --tail=200
+          fi
+          docker compose -f lightweight-docker-compose.yml down --volumes --remove-orphans
+          exit "$result"
+        }
+        trap cleanup EXIT
+
+        docker compose -f lightweight-docker-compose.yml config --quiet
+        docker compose -f lightweight-docker-compose.yml up -d --wait --wait-timeout 300 --pull always
+        curl --fail --silent --show-error http://127.0.0.1:8081/login >/dev/null
+        curl --fail --silent --show-error http://127.0.0.1:8081/learn/ | grep -F '<title>AI Learning Lab</title>' >/dev/null
+        curl --fail --silent --show-error http://127.0.0.1:8081/learn/how-llm-works/course/attention | grep -F '<title>AI Learning Lab</title>' >/dev/null
+        curl --fail --silent --show-error http://127.0.0.1:8081/learn/how-ai-agent-works/course/agent-loop | grep -F '<title>AI Learning Lab</title>' >/dev/null
+        curl --fail --silent --show-error http://127.0.0.1:8081/v3/api-docs >/dev/null
+        curl --fail --silent --show-error --request POST http://127.0.0.1:11434/api/generate \
+          --header 'Content-Type: application/json' \
+          --data '{"model":"qwen3.5:2b","prompt":"Provide a motivational quote","stream":false}' \
+          | grep -F '"done":true' >/dev/null
+
   runDocker-Jenkins:
     runs-on: ubuntu-latest
     services:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This does not mean the profiles can run side by side on the same machine. `light
 
 Use this most of the time for local work.
 
+It uses the same immutable backend, frontend, AI Lab, and model-mock releases as the reviewed server compatibility set. The authenticated commerce navigation therefore includes **AI Lab**, and signed-out deep lesson URLs return to the requested lesson after login.
+
 Start it with:
 
 ```bash

--- a/docs/AI_LAB_RELEASE.md
+++ b/docs/AI_LAB_RELEASE.md
@@ -29,9 +29,9 @@ The gateway waits for the backend and AI Lab health checks before starting where
 
 ## Profile behavior
 
-| Profile | Lab artifact | Model behavior | GPT-2 inspector | Intended use |
+| Profile | Application artifact strategy | Model behavior | GPT-2 inspector | Intended use |
 | --- | --- | --- | --- | --- |
-| `lightweight` | pulled `AI_LAB_IMAGE` | `ollama-mock`; deterministic legacy demos only | no | quick local app and course-shell work |
+| `lightweight` | pulled backend, frontend, `AI_LAB_IMAGE`, and model-mock compatibility set | `ollama-mock`; deterministic legacy demos only | no | quick local commerce and guided-course work |
 | `lightweight` + `docker-compose.ai-lab-build.yml` | built from sibling checkout | same lightweight mock | no | cross-repository frontend work |
 | `full` | pulled `AI_LAB_IMAGE` | Bonsai through Docker Model Runner adapter | no | normal full stack on the author's Mac |
 | `full` + `docker-compose.ai-lab-local.yml` | built from sibling checkout | Bonsai through adapter | yes, private and cached | model-internals teaching and development |

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -48,7 +48,9 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 The production compatibility set is the five first-party services above. `scripts/verify-release-images.py` checks that:
 
 - each production service uses a `tag@sha256` reference;
-- the full, lightweight, model-mock, and server profiles agree on shared mock and consumer releases;
+- full and server agree on backend, frontend, AI Lab, and consumer releases;
+- lightweight and server agree on backend, frontend, AI Lab, and model-mock releases;
+- the model-mock override agrees with the server model-mock release;
 - the AI Lab release runbook records the exact selected references;
 - with `--remote`, every manifest exists and contains both `linux/amd64` and `linux/arm64`.
 

--- a/docs/PROFILE_URLS.md
+++ b/docs/PROFILE_URLS.md
@@ -32,7 +32,7 @@ That gateway is the intended public surface for:
 - static images under `/images/...`
 - AI Learning Lab under `/learn/...`
 
-AI Learning Lab course content requires a valid application session in every profile. A signed-out browser is redirected to `/login` with the requested Lab path preserved in `returnTo`. The current full-local and server frontends return to that path after successful login. The lightweight profile intentionally keeps the recorded-course `3.6.16` frontend, which lands on `/` after login; reopen the requested Lab URL to continue. Raw `curl` checks below only prove that the static Lab shell is reachable through the gateway.
+AI Learning Lab course content requires a valid application session in every profile. A signed-out browser is redirected to `/login` with the requested Lab path preserved in `returnTo`, then returned to that path after successful login. Raw `curl` checks below only prove that the static Lab shell is reachable through the gateway.
 
 ## Mermaid Diagrams
 

--- a/docs/STUDENT_GUIDE.md
+++ b/docs/STUDENT_GUIDE.md
@@ -114,7 +114,7 @@ Keycloak SSO login:
 
 For the full SSO flow and the difference between password login and SSO, see [SSO_FLOW.md](SSO_FLOW.md).
 
-The AI Learning Lab requires a valid application session. If you open `/learn/` or a deep lesson URL while signed out, the Lab sends the browser to `/login` with a `returnTo` parameter. The full-local and server frontends return you to the requested Lab route after a successful application-password or SSO login. The lightweight profile intentionally retains the recorded-course `3.6.16` frontend; after signing in there, reopen the requested Lab route from the address bar.
+The AI Learning Lab requires a valid application session. If you open `/learn/` or a deep lesson URL while signed out, the Lab sends the browser to `/login` with a `returnTo` parameter. After a successful application-password or SSO login, every current profile returns you to the requested Lab route.
 
 For everyday work, prefer `8081`.
 

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.6.15
+    image: slawekradzyminski/backend:3.7.11@sha256:fb22a175b015a27b5d4f9a65784cf3bea59b35b33845f6c22a17a5cc2a9bfd68
     restart: always
     expose:
       - "4001"
@@ -38,7 +38,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.6.16
+    image: slawekradzyminski/frontend:3.7.8@sha256:e76c0e6ec1febc78a944ead7043f37cdc8bb3aff2c2d8d50b010ad74e983ae7f
     restart: always
     expose:
       - "80"

--- a/scripts/verify-release-images.py
+++ b/scripts/verify-release-images.py
@@ -88,16 +88,18 @@ def main() -> int:
         )
         release_images[service] = image
 
-    require(
-        full.get("consumer") == release_images["consumer"],
-        "full and server profiles must use the same consumer release",
-        failures,
-    )
-    require(
-        lightweight.get("ollama-mock") == release_images["ollama-mock"],
-        "lightweight and server profiles must use the same Ollama mock release",
-        failures,
-    )
+    for service in ("backend", "frontend", "ai-learning-lab", "consumer"):
+        require(
+            full.get(service) == release_images[service],
+            f"full and server profiles must use the same {service} release",
+            failures,
+        )
+    for service in ("backend", "frontend", "ai-learning-lab", "ollama-mock"):
+        require(
+            lightweight.get(service) == release_images[service],
+            f"lightweight and server profiles must use the same {service} release",
+            failures,
+        )
     require(
         model_mock.get("ollama") == release_images["ollama-mock"],
         "the model-mock override must use the production Ollama mock release",


### PR DESCRIPTION
## What changed

- promote lightweight backend to immutable 3.7.11
- promote lightweight frontend to immutable 3.7.8
- retain AI Learning Lab 0.1.2 and Ollama mock 1.0.6
- enforce full/lightweight/server compatibility-set agreement
- add a hosted lightweight runtime job for login, both course deep routes, OpenAPI, and mock generation
- update student, profile, and release documentation

## Verification

- all Compose variants render successfully
- five-image local and remote manifest checks pass
- exact lightweight images pulled and reached healthy state
- login, OpenAPI, image, Lab shell, Attention, Agent Loop, mock generation, authentication, and product catalog pass
- authenticated desktop navigation exposes AI Lab
- anonymous Agent Loop deep link returns to the exact lesson after password login
- both real Keycloak SSO tests pass sequentially
- all 28 unchanged AI Lab gateway/course Playwright tests pass