### PR TITLE
Release tested application compatibility set

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Only this full-local combination passes `VITE_AI_LIVE_RUNTIME_ENABLED=true` to t
 
 The full-local runtime currently installs Bonsai only. Live next-token probabilities and token counts therefore work, while the separate semantic-embedding control reports its designed unavailable state until an embedding model such as `embeddinggemma` is explicitly installed and routed. The guided embedding exercise and the GPT-2 embedding inspector remain available.
 
-Set `BACKEND_BUILD_CONTEXT`, `AI_LAB_BUILD_CONTEXT`, or `FRONTEND_BUILD_CONTEXT` if a repository is elsewhere. The override builds one compatible local stack from the checked-out backend, the commerce frontend without embedded Lab code, and the standalone AI Learning Lab. Deployment profiles default to the immutable multi-platform `slawekradzyminski/ai-learning-lab:0.1.2` manifest and may override it with `AI_LAB_IMAGE`. Production image tags and digests must be selected as one tested compatibility set; see [the release runbook](docs/AI_LAB_RELEASE.md).
+Set `BACKEND_BUILD_CONTEXT`, `AI_LAB_BUILD_CONTEXT`, or `FRONTEND_BUILD_CONTEXT` if a repository is elsewhere. The override builds one compatible local stack from the checked-out backend, the commerce frontend without embedded Lab code, and the standalone AI Learning Lab. Deployment profiles default to the immutable multi-platform `slawekradzyminski/ai-learning-lab:0.1.3` manifest and may override it with `AI_LAB_IMAGE`. Production image tags and digests must be selected as one tested compatibility set; see [the release runbook](docs/AI_LAB_RELEASE.md).
 
 Run the cross-repository gateway E2E check with:
 
@@ -247,7 +247,7 @@ Verify the actual Compose path (backend -> adapter -> Docker Model Runner):
 
 ```bash
 docker compose exec -T backend printenv OLLAMA_BASE_URL
-docker run --rm --network awesome-full_my-private-ntwk \
+docker run --rm --network awesome-full-native_my-private-ntwk \
   curlimages/curl:8.21.0 \
   http://ollama-dmr-adapter:11434/api/tags
 docker model ps

--- a/docker-compose.model-mock.yml
+++ b/docker-compose.model-mock.yml
@@ -14,7 +14,7 @@ services:
       - dmr
 
   ollama:
-    image: slawekradzyminski/ollama-mock:1.0.6@sha256:bb34ad70c6673f2f384e43da2b0984bb832eee7d76ee992365a93e612133c81c
+    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
     restart: unless-stopped
     ports:
       - "11434:11434"

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.11@sha256:fb22a175b015a27b5d4f9a65784cf3bea59b35b33845f6c22a17a5cc2a9bfd68
+    image: slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80
     restart: unless-stopped
     hostname: backend
     logging: *default-logging
@@ -62,7 +62,7 @@ services:
   frontend:
     # Release independently from aitesters-frontend. Do not update both tags
     # unless the AI Lab route is intentionally enabled on both hostnames.
-    image: slawekradzyminski/frontend:3.7.8@sha256:e76c0e6ec1febc78a944ead7043f37cdc8bb3aff2c2d8d50b010ad74e983ae7f
+    image: slawekradzyminski/frontend:3.7.9@sha256:6a6e2fc9eb1d3c4bd1d9cc3845d68998812ca7ca93c01f42d543ab5b73afcc03
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.2@sha256:632eaefe25727c0cbbec606ec0a65bd077f902f5001fc4b1fc7119c0634d60dc}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325}
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -252,7 +252,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.4@sha256:fb3aa512dca5e216dac77b2445da2a194dbad9a6ca66f6fd6b595d854b991726
+    image: slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96
     restart: unless-stopped
     logging: *default-logging
     env_file:
@@ -275,7 +275,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.6@sha256:bb34ad70c6673f2f384e43da2b0984bb832eee7d76ee992365a93e612133c81c
+    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full-native
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.11@sha256:fb22a175b015a27b5d4f9a65784cf3bea59b35b33845f6c22a17a5cc2a9bfd68
+    image: slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80
     restart: always
     expose:
       - "4001"
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.8@sha256:e76c0e6ec1febc78a944ead7043f37cdc8bb3aff2c2d8d50b010ad74e983ae7f
+    image: slawekradzyminski/frontend:3.7.9@sha256:6a6e2fc9eb1d3c4bd1d9cc3845d68998812ca7ca93c01f42d543ab5b73afcc03
     restart: always
     expose:
       - "80"
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.2@sha256:632eaefe25727c0cbbec606ec0a65bd077f902f5001fc4b1fc7119c0634d60dc}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325}
     restart: always
     expose:
       - "80"
@@ -210,7 +210,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.4@sha256:fb3aa512dca5e216dac77b2445da2a194dbad9a6ca66f6fd6b595d854b991726
+    image: slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96
     restart: always
     ports:
       - "4002:4002"

--- a/docs/AI_LAB_RELEASE.md
+++ b/docs/AI_LAB_RELEASE.md
@@ -46,7 +46,7 @@ The full-local model set currently contains Bonsai but no dedicated semantic-emb
 
 ## Production model capability boundary
 
-`slawekradzyminski/ollama-mock:1.0.6` supports the existing deterministic `/api/generate` scenarios. Direct verification of that image shows that it does not implement the learning-model contract:
+`slawekradzyminski/ollama-mock:1.0.7` supports the existing deterministic `/api/generate` scenarios. Direct verification of that image shows that it does not implement the learning-model contract:
 
 - a request with `logprobs: true` returns an ordinary canned generation without log probabilities;
 - `/api/embed` returns `404`;
@@ -66,11 +66,11 @@ Every production release selects a five-image first-party compatibility set, eve
 
 | Component | Immutable release reference |
 | --- | --- |
-| backend | `slawekradzyminski/backend:3.7.11@sha256:fb22a175b015a27b5d4f9a65784cf3bea59b35b33845f6c22a17a5cc2a9bfd68` |
-| primary frontend | `slawekradzyminski/frontend:3.7.8@sha256:e76c0e6ec1febc78a944ead7043f37cdc8bb3aff2c2d8d50b010ad74e983ae7f` |
-| AI Lab | `slawekradzyminski/ai-learning-lab:0.1.2@sha256:632eaefe25727c0cbbec606ec0a65bd077f902f5001fc4b1fc7119c0634d60dc` |
-| JMS consumer | `slawekradzyminski/consumer:3.3.4@sha256:fb3aa512dca5e216dac77b2445da2a194dbad9a6ca66f6fd6b595d854b991726` |
-| Ollama mock | `slawekradzyminski/ollama-mock:1.0.6@sha256:bb34ad70c6673f2f384e43da2b0984bb832eee7d76ee992365a93e612133c81c` |
+| backend | `slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80` |
+| primary frontend | `slawekradzyminski/frontend:3.7.9@sha256:6a6e2fc9eb1d3c4bd1d9cc3845d68998812ca7ca93c01f42d543ab5b73afcc03` |
+| AI Lab | `slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325` |
+| JMS consumer | `slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96` |
+| Ollama mock | `slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872` |
 
 These are registry-published multi-platform manifests. Do not deploy `latest`, a local-only tag, or a tag before its manifest can be pulled on the server architecture. A later release must replace the complete compatibility set intentionally and record its new digests.
 

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.11@sha256:fb22a175b015a27b5d4f9a65784cf3bea59b35b33845f6c22a17a5cc2a9bfd68
+    image: slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80
     restart: always
     expose:
       - "4001"
@@ -38,7 +38,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.8@sha256:e76c0e6ec1febc78a944ead7043f37cdc8bb3aff2c2d8d50b010ad74e983ae7f
+    image: slawekradzyminski/frontend:3.7.9@sha256:6a6e2fc9eb1d3c4bd1d9cc3845d68998812ca7ca93c01f42d543ab5b73afcc03
     restart: always
     expose:
       - "80"
@@ -46,7 +46,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.2@sha256:632eaefe25727c0cbbec606ec0a65bd077f902f5001fc4b1fc7119c0634d60dc}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325}
     restart: always
     expose:
       - "80"
@@ -110,7 +110,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.6@sha256:bb34ad70c6673f2f384e43da2b0984bb832eee7d76ee992365a93e612133c81c
+    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
     restart: always
     ports:
       - "11434:11434"

--- a/scripts/verify-ollama-config.sh
+++ b/scripts/verify-ollama-config.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DEFAULT_MODEL="hf.co/prism-ml/Bonsai-27B-gguf:Q1_0"
 QWEN_MODEL="hf.co/unsloth/Qwen3.5-2B-GGUF:Q4_K_M"
-MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.6@sha256:bb34ad70c6673f2f384e43da2b0984bb832eee7d76ee992365a93e612133c81c"
+MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872"
 
 default_config="$(OLLAMA_BASE_URL=http://ollama:11434 docker compose -f docker-compose.yml config)"
 grep -F "name: awesome-full-native" <<<"$default_config"


### PR DESCRIPTION
## Summary

- pin the July 20 application release set by immutable multi-platform manifest digest
- align lightweight, full, server, and model-mock profiles
- update the AI Lab release runbook and correct the full-profile network verification command

## Compatibility set

- backend 3.7.12 (`39809b9e…`)
- frontend 3.7.9 (`6a6e2fc9…`)
- AI Learning Lab 0.1.3 (`bcecb003…`)
- JMS consumer 3.3.5 (`1da0e051…`)
- Ollama mock 1.0.7 (`623170cf…`)

## Verification

- all modified Compose configurations pass `docker compose config --quiet`
- `verify-ollama-config.sh`, `verify-ai-lab-config.sh`, edge proxy checks, and adapter unit tests pass
- remote registry verification confirms all five immutable multi-platform manifests
- lightweight profile passes login, OpenAPI, mock generation, AI Lab shell, and both recorded deep routes
- authenticated browser check passes both course paths and the four-step visual introduction keyboard flow
- full profile is healthy with real Bonsai inference through the DMR adapter
- Artemis -> consumer 3.3.5 -> Mailpit delivery passes
- unchanged AI Lab course browser gate: 26/26 pass against localhost:8081

After CI, merge this PR before the Ansible production deployment.