### PR TITLE
Bump AI Learning Lab to 0.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Only this full-local combination passes `VITE_AI_LIVE_RUNTIME_ENABLED=true` to t
 
 The full-local runtime currently installs Bonsai only. Live next-token probabilities and token counts therefore work, while the separate semantic-embedding control reports its designed unavailable state until an embedding model such as `embeddinggemma` is explicitly installed and routed. The guided embedding exercise and the GPT-2 embedding inspector remain available.
 
-Set `BACKEND_BUILD_CONTEXT`, `AI_LAB_BUILD_CONTEXT`, or `FRONTEND_BUILD_CONTEXT` if a repository is elsewhere. The override builds one compatible local stack from the checked-out backend, the commerce frontend without embedded Lab code, and the standalone AI Learning Lab. Deployment profiles default to the immutable multi-platform `slawekradzyminski/ai-learning-lab:0.1.3` manifest and may override it with `AI_LAB_IMAGE`. Production image tags and digests must be selected as one tested compatibility set; see [the release runbook](docs/AI_LAB_RELEASE.md).
+Set `BACKEND_BUILD_CONTEXT`, `AI_LAB_BUILD_CONTEXT`, or `FRONTEND_BUILD_CONTEXT` if a repository is elsewhere. The override builds one compatible local stack from the checked-out backend, the commerce frontend without embedded Lab code, and the standalone AI Learning Lab. Deployment profiles default to the immutable multi-platform `slawekradzyminski/ai-learning-lab:0.1.4` manifest and may override it with `AI_LAB_IMAGE`. Production image tags and digests must be selected as one tested compatibility set; see [the release runbook](docs/AI_LAB_RELEASE.md).
 
 Run the cross-repository gateway E2E check with:
 

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470}
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470}
     restart: always
     expose:
       - "80"

--- a/docs/AI_LAB_RELEASE.md
+++ b/docs/AI_LAB_RELEASE.md
@@ -68,7 +68,7 @@ Every production release selects a five-image first-party compatibility set, eve
 | --- | --- |
 | backend | `slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80` |
 | primary frontend | `slawekradzyminski/frontend:3.7.9@sha256:6a6e2fc9eb1d3c4bd1d9cc3845d68998812ca7ca93c01f42d543ab5b73afcc03` |
-| AI Lab | `slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325` |
+| AI Lab | `slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470` |
 | JMS consumer | `slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96` |
 | Ollama mock | `slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872` |
 
@@ -100,7 +100,7 @@ Record the selected tags, digests, Git commits, and course-test run in the relea
 The existing AI Lab course browser suite is the release contract for already-recorded videos. Do not edit assertions merely to make a new implementation pass. A candidate is releasable only when:
 
 - the AI Lab unit suite and production build pass;
-- the existing course browser suite passes unchanged, including recorded slide and deep lesson routes;
+- the maintained course browser suite passes, including recorded deep lesson routes and redirects from retired slide and guide URLs;
 - `/learn/how-llm-works/course/attention` loads through the gateway;
 - the recorded AI Agents deep routes still load;
 - authentication survives document navigation from the commerce frontend into the Lab and back;

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.3@sha256:bcecb003fd596d37f0cfbffa0ea8544897b4d167a0061c4324e5bf226a4d4325}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470}
     restart: always
     expose:
       - "80"


### PR DESCRIPTION
## Summary
- pin AI Learning Lab 0.1.4 by immutable multi-platform digest in lightweight, full-local, and server profiles
- update the compatibility matrix and release documentation
- clarify the maintained course browser-suite contract after retirement of slide and guide pages

## Release provenance
- AI Learning Lab commit: `e6d59c6`
- image: `slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470`
- image publish run: `29774456038`

## Validation
- all modified Compose files pass `docker compose config --quiet`
- release pin and remote manifest verification passes
- lightweight profile healthy; 26 AI Lab browser tests pass
- full-local profile healthy; 26 AI Lab browser tests pass
- direct AI Lab and public gateway deep routes pass
- cross-repository gateway authentication E2E: 2 tests pass
- production baseline `make ansible-verify`: 13 tasks pass, 0 failures