### PR TITLE
Bump AI Learning Lab to 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Only this full-local combination passes `VITE_AI_LIVE_RUNTIME_ENABLED=true` to t
 
 The full-local runtime currently installs Bonsai only. Live next-token probabilities and token counts therefore work, while the separate semantic-embedding control reports its designed unavailable state until an embedding model such as `embeddinggemma` is explicitly installed and routed. The guided embedding exercise and the GPT-2 embedding inspector remain available.
 
-Set `BACKEND_BUILD_CONTEXT`, `AI_LAB_BUILD_CONTEXT`, or `FRONTEND_BUILD_CONTEXT` if a repository is elsewhere. The override builds one compatible local stack from the checked-out backend, the commerce frontend without embedded Lab code, and the standalone AI Learning Lab. Deployment profiles default to the immutable multi-platform `slawekradzyminski/ai-learning-lab:0.1.4` manifest and may override it with `AI_LAB_IMAGE`. Production image tags and digests must be selected as one tested compatibility set; see [the release runbook](docs/AI_LAB_RELEASE.md).
+Set `BACKEND_BUILD_CONTEXT`, `AI_LAB_BUILD_CONTEXT`, or `FRONTEND_BUILD_CONTEXT` if a repository is elsewhere. The override builds one compatible local stack from the checked-out backend, the commerce frontend without embedded Lab code, and the standalone AI Learning Lab. Deployment profiles default to the immutable multi-platform `slawekradzyminski/ai-learning-lab:0.1.5` manifest and may override it with `AI_LAB_IMAGE`. Production image tags and digests must be selected as one tested compatibility set; see [the release runbook](docs/AI_LAB_RELEASE.md).
 
 Run the cross-repository gateway E2E check with:
 
@@ -454,6 +454,7 @@ Quick public verification:
 ```bash
 curl -i https://awesome.byst.re/login
 curl -i https://awesome.byst.re/learn/
+curl -i https://awesome.byst.re/learn/how-machines-learn/course/learning-from-mistakes
 curl -i https://awesome.byst.re/learn/how-llm-works/course/attention
 curl -i https://awesome.byst.re/v3/api-docs
 curl -i https://awesome.byst.re/images/iphone.png

--- a/ansible/inventory/group_vars/production/main.yml
+++ b/ansible/inventory/group_vars/production/main.yml
@@ -105,6 +105,8 @@ verify_urls:
 verify_ai_lab_urls:
   - url: http://127.0.0.1/learn/
     content_pattern: "<title>AI Learning Lab</title>"
+  - url: http://127.0.0.1/learn/how-machines-learn/course/learning-from-mistakes
+    content_pattern: "<title>AI Learning Lab</title>"
   - url: http://127.0.0.1/learn/how-llm-works/course/attention
     content_pattern: "<title>AI Learning Lab</title>"
   - url: http://127.0.0.1/learn/how-ai-agent-works/course/agent-loop

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -73,7 +73,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.5@sha256:8b51f5443ed1fd610b5b924851b1e4047c95fbccf2b16297715cd9ccff698d2b}
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.5@sha256:8b51f5443ed1fd610b5b924851b1e4047c95fbccf2b16297715cd9ccff698d2b}
     restart: always
     expose:
       - "80"

--- a/docs/AI_LAB_RELEASE.md
+++ b/docs/AI_LAB_RELEASE.md
@@ -68,7 +68,7 @@ Every production release selects a five-image first-party compatibility set, eve
 | --- | --- |
 | backend | `slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80` |
 | primary frontend | `slawekradzyminski/frontend:3.7.9@sha256:6a6e2fc9eb1d3c4bd1d9cc3845d68998812ca7ca93c01f42d543ab5b73afcc03` |
-| AI Lab | `slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470` |
+| AI Lab | `slawekradzyminski/ai-learning-lab:0.1.5@sha256:8b51f5443ed1fd610b5b924851b1e4047c95fbccf2b16297715cd9ccff698d2b` |
 | JMS consumer | `slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96` |
 | Ollama mock | `slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872` |
 
@@ -128,11 +128,12 @@ Deploy through Ansible:
 make ansible-deploy
 ```
 
-The verification role retries startup-sensitive requests and checks both the Lab shell and the recorded Attention deep route for the AI Learning Lab HTML marker. After Ansible succeeds, verify the public TLS path as well:
+The verification role retries startup-sensitive requests and checks the Lab shell plus representative deep routes from all three courses for the AI Learning Lab HTML marker. After Ansible succeeds, verify the public TLS path as well:
 
 ```bash
 curl -I https://awesome.byst.re/learn
 curl -fsS https://awesome.byst.re/learn/ | grep -F '<title>AI Learning Lab</title>'
+curl -fsS https://awesome.byst.re/learn/how-machines-learn/course/learning-from-mistakes | grep -F '<title>AI Learning Lab</title>'
 curl -fsS https://awesome.byst.re/learn/how-llm-works/course/attention | grep -F '<title>AI Learning Lab</title>'
 curl -fsS https://awesome.byst.re/learn/how-ai-agent-works/course/agent-loop | grep -F '<title>AI Learning Lab</title>'
 ```

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - my-private-ntwk
 
   ai-learning-lab:
-    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.4@sha256:35ef645bc30dde3cd63f9735e3efcb6a59ab3440ce951f6c3bcafead4763f470}
+    image: ${AI_LAB_IMAGE:-slawekradzyminski/ai-learning-lab:0.1.5@sha256:8b51f5443ed1fd610b5b924851b1e4047c95fbccf2b16297715cd9ccff698d2b}
     restart: always
     expose:
       - "80"


### PR DESCRIPTION
## What changed

- promotes `slawekradzyminski/ai-learning-lab:0.1.5` using immutable manifest digest `sha256:8b51f5443ed1fd610b5b924851b1e4047c95fbccf2b16297715cd9ccff698d2b`
- keeps the default, lightweight, and production-server Compose profiles synchronized
- records the new compatibility-set reference in the release runbook
- adds the new How Machines Learn entry route to Ansible and public release verification

## Release provenance

- AI Learning Lab commit: `c8f2d37f206386c9abfc1114d549cd315a439f52`
- tag: `v0.1.5`
- publish workflow: https://github.com/slawekradzyminski/ai-learning-lab/actions/runs/30194580207
- published platforms: `linux/amd64`, `linux/arm64`

## Validation

- all three modified Compose files pass `docker compose config --quiet`
- `python3 scripts/verify-release-images.py --remote` verifies all five first-party release pins and remote manifests
- `bash scripts/verify-ai-lab-config.sh` passes
- AI Learning Lab: 169 unit tests and 27 course-browser tests passed
- direct container smoke routes passed
- Awesome LocalStack gateway integration: 2 Playwright tests passed

Unrelated local rate-limit tuning and temporary files were deliberately excluded from this PR.