### PR TITLE
Purge retired AI Learning Lab from production stack

### DIFF
--- a/ansible/inventory/group_vars/production/main.yml
+++ b/ansible/inventory/group_vars/production/main.yml
@@ -123,6 +123,10 @@ verify_urls:
     status_code: 404
   - url: http://127.0.0.1/mailhog/
     status_code: 404
+  - url: http://127.0.0.1/learn/
+    status_code: 404
+  - url: http://127.0.0.1/ai-learning-lab
+    status_code: 404
 
 verify_retries: 12
 verify_delay_seconds: 10

--- a/ansible/roles/verify/tasks/main.yml
+++ b/ansible/roles/verify/tasks/main.yml
@@ -439,6 +439,17 @@
   retries: "{{ verify_retries }}"
   delay: "{{ verify_delay_seconds }}"
 
+- name: Verify retired Learning Lab routes stay closed on aitesters
+  ansible.builtin.uri:
+    url: "http://127.0.0.1{{ item }}"
+    headers:
+      Host: "{{ aitesters_hostname }}"
+    status_code: 404
+    return_content: false
+  loop:
+    - /learn/
+    - /ai-learning-lab
+
 - name: Sign in to aitesters with seeded local admin
   ansible.builtin.uri:
     url: http://127.0.0.1/api/v1/users/signin

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80
+    image: slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69
     restart: unless-stopped
     hostname: backend
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full-native
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80
+    image: slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69
     restart: always
     expose:
       - "4001"

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -46,7 +46,7 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 
 | Service | Immutable image |
 | --- | --- |
-| Backend | `slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80` |
+| Backend | `slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69` |
 | Frontend | `slawekradzyminski/frontend:3.7.10@sha256:62ac2049cb928a62cc2f45221dc04b8510d1239793866c5ef19f29525e219bf1` |
 | Consumer | `slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96` |
 | Ollama mock | `slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872` |

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.12@sha256:39809b9e9fdc05fe33294357e5f91c5c37feb1afd60eefda6d2ae580b88bae80
+    image: slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69
     restart: always
     expose:
       - "4001"

--- a/nginx/conf.d/app-gateway.conf
+++ b/nginx/conf.d/app-gateway.conf
@@ -78,6 +78,23 @@ server {
     access_log off;
   }
 
+  # The Learning Lab is reviewed outside this production stack.
+  location = /learn {
+    return 404;
+  }
+
+  location ^~ /learn/ {
+    return 404;
+  }
+
+  location = /ai-learning-lab {
+    return 404;
+  }
+
+  location ^~ /ai-learning-lab/ {
+    return 404;
+  }
+
   location = /mailpit {
     return 404;
   }
@@ -201,6 +218,23 @@ server {
     alias /usr/share/nginx/html/branding/;
     try_files $uri =404;
     access_log off;
+  }
+
+  # The Learning Lab is reviewed outside this production stack.
+  location = /learn {
+    return 404;
+  }
+
+  location ^~ /learn/ {
+    return 404;
+  }
+
+  location = /ai-learning-lab {
+    return 404;
+  }
+
+  location ^~ /ai-learning-lab/ {
+    return 404;
   }
 
   location / {

--- a/nginx/conf.d/lightweight-app-gateway.conf
+++ b/nginx/conf.d/lightweight-app-gateway.conf
@@ -74,6 +74,23 @@ server {
     access_log off;
   }
 
+  # The Learning Lab is reviewed outside this production stack.
+  location = /learn {
+    return 404;
+  }
+
+  location ^~ /learn/ {
+    return 404;
+  }
+
+  location = /ai-learning-lab {
+    return 404;
+  }
+
+  location ^~ /ai-learning-lab/ {
+    return 404;
+  }
+
   location / {
     proxy_pass http://frontend:80;
     proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

- close the retired `/learn` and `/ai-learning-lab` routes on both `awesome.byst.re` and `aitesters.byst.re`
- add production verification for both host-routed 404 boundaries
- pin backend `3.7.13` by immutable digest; this release removes the GPT-2 inspector and AI-learning-only Ollama APIs
- keep the previously merged monitoring work and Compose profiles intact

The explicit gateway 404s are intentional tombstones: they prevent the frontend SPA fallback from making retired routes appear live.

## Validation

- `docker compose -f docker-compose.yml config --quiet`
- `docker compose -f docker-compose.server.yml config --quiet`
- `docker compose -f lightweight-docker-compose.yml config --quiet`
- `python3 scripts/verify-release-images.py --remote`
- `bash scripts/verify-edge-proxy.sh`
- `bash scripts/verify-ollama-config.sh`
- isolated gateway smoke test: frontend direct route remains reachable, while both production hosts return 404 for `/learn` and `/ai-learning-lab`