### PR TITLE
Remove retired Learning Lab tombstones

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   verifyEdgeProxy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
     - name: Verify trusted edge proxy sanitization
       run: bash ./scripts/verify-edge-proxy.sh
 
@@ -21,14 +21,14 @@ jobs:
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
     - name: Build and run Docker Compose
       run: USE_OLLAMA_MOCK=true bash ./run-docker-compose.sh
 
   verifyOllamaConfig:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
     - name: Verify Docker Model Runner and mock overrides
       run: bash ./scripts/verify-ollama-config.sh
     - name: Test Docker Model Runner adapter
@@ -37,7 +37,7 @@ jobs:
   verifyReleaseImages:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
     - name: Verify immutable first-party image set
       run: python3 scripts/verify-release-images.py
 
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
     - name: Run published lightweight compatibility set
       shell: bash
       run: |
@@ -78,6 +78,6 @@ jobs:
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     steps:
-    - uses: actions/checkout@v7.0.0
+    - uses: actions/checkout@v7.0.1
     - name: Build and run Docker Compose CI version
       run: bash ./run-docker-compose-jenkins.sh

--- a/.github/workflows/verify-release-images.yml
+++ b/.github/workflows/verify-release-images.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
       - uses: docker/setup-buildx-action@v4.2.0
       - name: Verify immutable pins and multi-platform manifests
         run: python3 scripts/verify-release-images.py --remote

--- a/ansible/inventory/group_vars/production/main.yml
+++ b/ansible/inventory/group_vars/production/main.yml
@@ -123,10 +123,5 @@ verify_urls:
     status_code: 404
   - url: http://127.0.0.1/mailhog/
     status_code: 404
-  - url: http://127.0.0.1/learn/
-    status_code: 404
-  - url: http://127.0.0.1/ai-learning-lab
-    status_code: 404
-
 verify_retries: 12
 verify_delay_seconds: 10

--- a/ansible/roles/verify/tasks/main.yml
+++ b/ansible/roles/verify/tasks/main.yml
@@ -439,17 +439,6 @@
   retries: "{{ verify_retries }}"
   delay: "{{ verify_delay_seconds }}"
 
-- name: Verify retired Learning Lab routes stay closed on aitesters
-  ansible.builtin.uri:
-    url: "http://127.0.0.1{{ item }}"
-    headers:
-      Host: "{{ aitesters_hostname }}"
-    status_code: 404
-    return_content: false
-  loop:
-    - /learn/
-    - /ai-learning-lab
-
 - name: Sign in to aitesters with seeded local admin
   ansible.builtin.uri:
     url: http://127.0.0.1/api/v1/users/signin

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -63,7 +63,7 @@ services:
 
   frontend:
     # Release independently from aitesters-frontend.
-    image: slawekradzyminski/frontend:3.7.10@sha256:62ac2049cb928a62cc2f45221dc04b8510d1239793866c5ef19f29525e219bf1
+    image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.10@sha256:62ac2049cb928a62cc2f45221dc04b8510d1239793866c5ef19f29525e219bf1
+    image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
     restart: always
     expose:
       - "80"

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -47,7 +47,7 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 | Service | Immutable image |
 | --- | --- |
 | Backend | `slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69` |
-| Frontend | `slawekradzyminski/frontend:3.7.10@sha256:62ac2049cb928a62cc2f45221dc04b8510d1239793866c5ef19f29525e219bf1` |
+| Frontend | `slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8` |
 | Consumer | `slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96` |
 | Ollama mock | `slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872` |
 

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.10@sha256:62ac2049cb928a62cc2f45221dc04b8510d1239793866c5ef19f29525e219bf1
+    image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
     restart: always
     expose:
       - "80"

--- a/nginx/conf.d/app-gateway.conf
+++ b/nginx/conf.d/app-gateway.conf
@@ -78,23 +78,6 @@ server {
     access_log off;
   }
 
-  # The Learning Lab is reviewed outside this production stack.
-  location = /learn {
-    return 404;
-  }
-
-  location ^~ /learn/ {
-    return 404;
-  }
-
-  location = /ai-learning-lab {
-    return 404;
-  }
-
-  location ^~ /ai-learning-lab/ {
-    return 404;
-  }
-
   location = /mailpit {
     return 404;
   }
@@ -218,23 +201,6 @@ server {
     alias /usr/share/nginx/html/branding/;
     try_files $uri =404;
     access_log off;
-  }
-
-  # The Learning Lab is reviewed outside this production stack.
-  location = /learn {
-    return 404;
-  }
-
-  location ^~ /learn/ {
-    return 404;
-  }
-
-  location = /ai-learning-lab {
-    return 404;
-  }
-
-  location ^~ /ai-learning-lab/ {
-    return 404;
   }
 
   location / {

--- a/nginx/conf.d/lightweight-app-gateway.conf
+++ b/nginx/conf.d/lightweight-app-gateway.conf
@@ -74,23 +74,6 @@ server {
     access_log off;
   }
 
-  # The Learning Lab is reviewed outside this production stack.
-  location = /learn {
-    return 404;
-  }
-
-  location ^~ /learn/ {
-    return 404;
-  }
-
-  location = /ai-learning-lab {
-    return 404;
-  }
-
-  location ^~ /ai-learning-lab/ {
-    return 404;
-  }
-
   location / {
     proxy_pass http://frontend:80;
     proxy_http_version 1.1;


### PR DESCRIPTION
## Summary

- remove the explicit `/learn` and `/ai-learning-lab` gateway tombstones
- remove the corresponding production 404 assertions
- update `actions/checkout` from 7.0.0 to 7.0.1
- pin cleaned frontend `3.7.11` by immutable digest `sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8`

The generic SPA fallback now handles unknown routes again. No Learning Lab service, frontend route, navigation link, or backend API is restored.

## Validation

- all three Compose configurations validate
- remote immutable image verification passes
- edge-proxy and Ollama configuration checks pass
- isolated Docker verification confirms direct frontend and both host-routed gateway paths use the same SPA fallback
- frontend release CI: 443 unit tests, all three Playwright shards, runtime image smoke test, and multi-platform publish