### PR TITLE
Refresh platform dependencies and container images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
           - minor
           - patch
   - package-ecosystem: docker
-    directory: /ollama
+    directory: /ollama-dmr-adapter
     schedule:
       interval: weekly
     groups:

--- a/README.md
+++ b/README.md
@@ -429,7 +429,8 @@ Production hardening in this profile:
 - the main backend and consumer have explicit JVM heap and container memory limits
 - aitesters backend and frontend are internal-only behind the same gateway
 - images are served directly by the gateway
-- the aitesters frontend remains independently versioned
+- the aitesters backend and frontend reuse the exact current application images;
+  their sandbox behavior comes from runtime configuration, not stale releases
 
 Use `make ansible-tunnel-grafana` and open `http://localhost:3000` to inspect
 the provisioned **Production Resources** and

--- a/README.md
+++ b/README.md
@@ -142,6 +142,18 @@ For a clean, verified startup that also removes obsolete services, use:
 ./run-docker-compose.sh
 ```
 
+The full profile uses InfluxDB `1.12.4`. Before starting it against a named
+volume last written by the older `1.8` image, back up the `influxdb-storage`
+volume. InfluxDB 3 is a separate migration target and is not a drop-in image
+replacement for this profile.
+
+InfluxDB `1.12.4` runs as UID/GID `1500`. A volume created by the older image
+may still be owned by UID `999` or root and must be backed up and recursively
+re-owned before the first `1.12.4` startup. The Artemis `2.55.0` image uses the
+explicit `activemq-data` volume; do not attach an anonymous instance volume
+created by the retired `apache/activemq-artemis` image. Drain or export pending
+messages before the first broker upgrade.
+
 This local full stack intentionally starts the backend with `docker,demo`, so PostgreSQL-backed demo users, products, and sample orders are available with the same seeded admin credentials as the lightweight profile.
 
 Main app URL:

--- a/docker-compose.model-mock.yml
+++ b/docker-compose.model-mock.yml
@@ -14,7 +14,7 @@ services:
       - dmr
 
   ollama:
-    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
+    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
     restart: unless-stopped
     ports:
       - "11434:11434"

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69
+    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
     restart: unless-stopped
     hostname: backend
     logging: *default-logging
@@ -62,8 +62,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    # Release independently from aitesters-frontend.
-    image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
+    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -73,7 +72,7 @@ services:
       - my-private-ntwk
 
   aitesters-backend:
-    image: slawekradzyminski/backend:3.7.9
+    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
     restart: unless-stopped
     hostname: aitesters-backend
     logging: *default-logging
@@ -112,7 +111,7 @@ services:
       - my-private-ntwk
 
   aitesters-frontend:
-    image: slawekradzyminski/frontend:3.7.6
+    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -356,7 +355,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96
+    image: slawekradzyminski/consumer:3.3.6@sha256:a4f980d7c88ce7ec628e58bfeeed8f9390b28251ae198dbd179eac6e7c4f8b89
     restart: unless-stopped
     logging: *default-logging
     env_file:
@@ -381,7 +380,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
+    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -122,7 +122,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.31.2-trixie
+    image: nginx:1.31.3-trixie@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942
     restart: unless-stopped
     logging: *default-logging
     depends_on:
@@ -146,7 +146,7 @@ services:
       - my-private-ntwk
 
   edge:
-    image: nginx:1.31.2-trixie
+    image: nginx:1.31.3-trixie@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942
     restart: unless-stopped
     network_mode: host
     logging: *default-logging
@@ -240,7 +240,7 @@ services:
       - my-private-ntwk
 
   prometheus:
-    image: prom/prometheus:v3.13.1@sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893
+    image: prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69
     restart: unless-stopped
     logging: *default-logging
     command:
@@ -307,7 +307,7 @@ services:
       - my-private-ntwk
 
   activemq:
-    image: apache/activemq-artemis:2.42.0
+    image: apache/artemis:2.55.0@sha256:a192eee9c46e6352625ca9dbf0beebe4a34c363111c628bbb10c4aff1227341d
     restart: unless-stopped
     logging: *default-logging
     env_file:
@@ -315,8 +315,7 @@ services:
         required: false
     environment:
       ANONYMOUS_LOGIN: "false"
-      EXTRA_ARGS: --http-host 0.0.0.0 --relax-jolokia --no-autotune
-      BROKER_CONFIG_GLOBAL_MAX_SIZE: 256mb
+      EXTRA_ARGS: --http-host 0.0.0.0 --relax-jolokia --no-autotune --global-max-size 256M
       JAVA_ARGS: >-
         -XX:AutoBoxCacheMax=20000
         -XX:+PrintClassHistogram
@@ -334,6 +333,8 @@ services:
     expose:
       - "61616"
       - "8161"
+    volumes:
+      - activemq-data:/var/lib/artemis-instance
     hostname: activemq
     mem_limit: 768m
     networks:
@@ -392,6 +393,7 @@ services:
       - my-private-ntwk
 
 volumes:
+  activemq-data:
   postgres-data:
   prometheus-data:
   alertmanager-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full-native
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69
+    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
     restart: always
     expose:
       - "4001"
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
+    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
     restart: always
     expose:
       - "80"
@@ -194,7 +194,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96
+    image: slawekradzyminski/consumer:3.3.6@sha256:a4f980d7c88ce7ec628e58bfeeed8f9390b28251ae198dbd179eac6e7c4f8b89
     restart: always
     ports:
       - "4002:4002"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.7.0
+    image: quay.io/keycloak/keycloak:26.7.0@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
     restart: always
     command:
       - start-dev
@@ -101,7 +101,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.31.2-trixie
+    image: nginx:1.31.3-trixie@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942
     restart: always
     depends_on:
       frontend:
@@ -133,7 +133,7 @@ services:
       - my-private-ntwk
 
   prometheus:
-    image: prom/prometheus:v3.13.0
+    image: prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69
     restart: always
     volumes:
       - ./prometheus/:/etc/prometheus/
@@ -145,7 +145,7 @@ services:
       - my-private-ntwk
 
   grafana:
-    image: grafana/grafana:13.1.0
+    image: grafana/grafana:13.1.1@sha256:7cb8c64c4d57a57e734073f3cc94620adb24a0acb929bd80ba9f14017e3a975b
     environment:
       GF_SECURITY_ADMIN_PASSWORD: grafana
     volumes:
@@ -164,19 +164,19 @@ services:
       - my-private-ntwk
 
   activemq:
-    image: apache/activemq-artemis:2.42.0
+    image: apache/artemis:2.55.0@sha256:a192eee9c46e6352625ca9dbf0beebe4a34c363111c628bbb10c4aff1227341d
     restart: always
     environment:
       ARTEMIS_USER: admin
       ARTEMIS_PASSWORD: admin
       ANONYMOUS_LOGIN: "true"
-      EXTRA_ARGS: --http-host 0.0.0.0 --relax-jolokia --no-autotune
-      DISABLE_SECURITY: true
-      BROKER_CONFIG_GLOBAL_MAX_SIZE: 512mb
+      EXTRA_ARGS: --http-host 0.0.0.0 --relax-jolokia --no-autotune --global-max-size 512M
     ports:
       - "61616:61616"
       - "8161:8161"
       - "5672:5672"
+    volumes:
+      - activemq-data:/var/lib/artemis-instance
     hostname: activemq
     networks:
       - my-private-ntwk
@@ -213,7 +213,7 @@ services:
       - my-private-ntwk
 
   influxdb:
-    image: influxdb:1.8
+    image: influxdb:1.12.4@sha256:7f65020ddef923f0366dfee0ce753adc0d20b97b0b110b0988c03e0426932396
     ports:
       - '8086:8086'
     volumes:
@@ -226,6 +226,7 @@ services:
       - my-private-ntwk
 
 volumes:
+  activemq-data:
   influxdb-storage:
   postgres-data:
 

--- a/docs/ANSIBLE.md
+++ b/docs/ANSIBLE.md
@@ -150,6 +150,16 @@ The Compose task uses convergent settings rather than forced recreation:
 
 That keeps repeated deploys idempotent when the server state already matches the repo.
 
+### Artemis 2.55 volume migration
+
+The official `apache/artemis` image uses the explicit `activemq-data` volume.
+The retired `apache/activemq-artemis` image created an anonymous instance
+volume whose launch scripts refer to the old distribution layout and cannot be
+reused by Artemis 2.55. Before the first deployment of Artemis 2.55, drain or
+export pending messages and retain a backup of the anonymous volume. The first
+convergent deployment creates the new named volume; do not delete the old
+anonymous volume until the Artemis-to-consumer delivery check has passed.
+
 ### Verification as part of deploy
 
 The `verify` role remains separate so it can still be run on demand, but it is also included in `deploy.yml`.

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -46,19 +46,26 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 
 | Service | Immutable image |
 | --- | --- |
-| Backend | `slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69` |
-| Frontend | `slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8` |
-| Consumer | `slawekradzyminski/consumer:3.3.5@sha256:1da0e051f9fba1492e6597ae385aee64a78ebc434928bddd84bd1fd8a222fe96` |
-| Ollama mock | `slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872` |
+| Backend | `slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7` |
+| Frontend | `slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112` |
+| Consumer | `slawekradzyminski/consumer:3.3.6@sha256:a4f980d7c88ce7ec628e58bfeeed8f9390b28251ae198dbd179eac6e7c4f8b89` |
+| Ollama mock | `slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e` |
 
 ## LocalStack compatibility gate
 
 The production compatibility set is the four first-party services above.
+The main and `aitesters` variants do not have separate application release
+lines: `aitesters-backend` must use the exact current backend reference and
+`aitesters-frontend` must use the exact current frontend reference. Their
+behavior differs through runtime profiles and routing, not through old images.
+Previous application releases remain rollback references only.
+
 `scripts/verify-release-images.py` checks that:
 
 - each production service uses a `tag@sha256` reference;
 - full and server agree on backend, frontend, and consumer releases;
 - lightweight and server agree on backend, frontend, and model-mock releases;
+- the server's `aitesters` services reuse the exact backend and frontend releases;
 - the model-mock override agrees with the server model-mock release;
 - this document records the exact selected references;
 - with `--remote`, every manifest exists and contains both `linux/amd64` and `linux/arm64`.
@@ -76,4 +83,4 @@ Static pin verification runs in normal LocalStack CI. `.github/workflows/verify-
 7. Run the affected direct-service, gateway, lightweight, and full gates.
 8. Merge the LocalStack release PR, create an encrypted production backup when stateful services are affected, and deploy through Ansible.
 
-An application release does not require rebuilding unchanged applications. It does require retaining their known-good immutable references in the reviewed compatibility set.
+An application release does not require rebuilding unchanged applications. It does require retaining their known-good immutable references in the reviewed compatibility set. Backward compatibility is maintained for persisted data and external contracts where required; the deployment does not keep stale application images running as compatibility variants.

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -31,12 +31,12 @@ The Docker Hub token should be scoped to repository image writes and stored sepa
 
 The workflows use action generations whose JavaScript entrypoints target Node.js 24:
 
-- `actions/checkout@v7.0.0`
+- `actions/checkout@v7.0.1`
 - `actions/setup-node@v7.0.0`
 - `actions/setup-java@v5.6.0`
 - `docker/setup-qemu-action@v4.2.0`
 - `docker/setup-buildx-action@v4.2.0`
-- `docker/login-action@v4.4.0`
+- `docker/login-action@v4.6.0`
 - `docker/metadata-action@v6.2.0`
 - `docker/build-push-action@v7.3.0`
 

--- a/docs/PRODUCTION_MONITORING_PLAN.md
+++ b/docs/PRODUCTION_MONITORING_PLAN.md
@@ -77,7 +77,7 @@ those tests.
 ### Monitoring image revision audit
 
 The monitoring images were re-audited against their authoritative upstream
-releases and registries on 2026-07-26. The Compose file uses exact stable tags
+releases and registries on 2026-08-01. The Compose file uses exact stable tags
 and immutable multi-architecture manifest digests rather than floating `latest`
 tags.
 
@@ -85,7 +85,7 @@ tags.
 | --- | --- | --- |
 | Node Exporter | `v1.12.1` | `sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0` |
 | cAdvisor | `v0.60.5` | `sha256:763aecf1c32c2be8a1a75f9abfc2fc461005c9dbbaa39cb356b354aac1296dbe` |
-| Prometheus | `v3.13.1` | `sha256:3c42b892cf723fa54d2f262c37a0e1f80aa8c8ddb1da7b9b0df9455a35a7f893` |
+| Prometheus | `v3.13.2` | `sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69` |
 | Grafana | `13.1.1` | `sha256:7cb8c64c4d57a57e734073f3cc94620adb24a0acb929bd80ba9f14017e3a975b` |
 | Alertmanager | `v0.32.1` | `sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286` |
 | Blackbox Exporter | `v0.28.0` | `sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc` |

--- a/docs/PROFILE_URLS.md
+++ b/docs/PROFILE_URLS.md
@@ -289,7 +289,8 @@ Special behavior:
 - `https://awesome.byst.re/mailpit/api/v1/messages` is blocked with `404`
 - `https://awesome.byst.re/mailpit/` is blocked with `404`
 - Mailpit remains available only through SSH tunnelling to remote `127.0.0.1:8025`
-- `aitesters.byst.re` runs an additional backend with the Spring `local` profile
+- `aitesters.byst.re` runs the current backend image with the Spring `aitesters` profile
+- its frontend is the same current frontend image used by `awesome.byst.re`
 - `aitesters.byst.re` uses H2 in-memory data and seeded local demo users, including the demo admin
 - `aitesters.byst.re` exposes local/test helpers such as `/api/v1/local/email/outbox` by design
 - `aitesters.byst.re` is reset daily by the `aitesters-reset.timer` systemd timer

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.13@sha256:c7c7d3298bd2b140bc1f914c147d1932b6d493d2a16a793a350f3ad9bde6fa69
+    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
     restart: always
     expose:
       - "4001"
@@ -38,7 +38,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.11@sha256:b1c0bb05b1aaf5ca8e38552dcb137d8ba908975fa1c8c0eb7d80ca003afa03f8
+    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
     restart: always
     expose:
       - "80"
@@ -94,7 +94,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872
+    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
     restart: always
     ports:
       - "11434:11434"

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - my-private-ntwk
 
   keycloak:
-    image: quay.io/keycloak/keycloak:26.7.0
+    image: quay.io/keycloak/keycloak:26.7.0@sha256:0f198be292568439d700cdbfb893e69a6009bb43a94a06a945b1d3d506c76b13
     restart: always
     command:
       - start-dev
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   keycloak-init:
-    image: curlimages/curl:8.13.0
+    image: curlimages/curl:8.21.0
     entrypoint: ["/bin/sh", "/init/init-mock-users.sh"]
     volumes:
       - ./keycloak/init-mock-users.sh:/init/init-mock-users.sh:ro
@@ -76,7 +76,7 @@ services:
       - my-private-ntwk
 
   gateway:
-    image: nginx:1.31.2-trixie
+    image: nginx:1.31.3-trixie@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942
     restart: unless-stopped
     depends_on:
       frontend:

--- a/ollama-dmr-adapter/Dockerfile
+++ b/ollama-dmr-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3.14.6-alpine@sha256:26730869004e2b9c4b9ad09cab8625e81d256d1ce97e72df5520e806b1709f92
 
 WORKDIR /app
 COPY adapter.py /app/adapter.py

--- a/scripts/verify-edge-proxy.sh
+++ b/scripts/verify-edge-proxy.sh
@@ -28,7 +28,7 @@ docker run --detach --rm \
   --network "${network}" \
   --network-alias edge \
   --volume "${test_config}:/etc/nginx/conf.d/default.conf:ro" \
-  nginx:1.31.2-trixie >/dev/null
+  nginx:1.31.3-trixie@sha256:5a88c9c45479443d7be2eadc894b4ed0a9801bae03d97a5760ae13b5c2005942 >/dev/null
 
 response=""
 for _ in $(seq 1 20); do

--- a/scripts/verify-ollama-config.sh
+++ b/scripts/verify-ollama-config.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DEFAULT_MODEL="hf.co/prism-ml/Bonsai-27B-gguf:Q1_0"
 QWEN_MODEL="hf.co/unsloth/Qwen3.5-2B-GGUF:Q4_K_M"
-MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.7@sha256:623170cfb5bbe18b8584ca3683c69023af2267d3534812136eecef39e10f9872"
+MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e"
 
 default_config="$(OLLAMA_BASE_URL=http://ollama:11434 docker compose -f docker-compose.yml config)"
 grep -F "name: awesome-full-native" <<<"$default_config"

--- a/scripts/verify-release-images.py
+++ b/scripts/verify-release-images.py
@@ -100,6 +100,16 @@ def main() -> int:
             failures,
         )
     require(
+        server.get("aitesters-backend") == release_images["backend"],
+        "the aitesters backend must reuse the current backend release",
+        failures,
+    )
+    require(
+        server.get("aitesters-frontend") == release_images["frontend"],
+        "the aitesters frontend must reuse the current frontend release",
+        failures,
+    )
+    require(
         model_mock.get("ollama") == release_images["ollama-mock"],
         "the model-mock override must use the production Ollama mock release",
         failures,


### PR DESCRIPTION
## Summary
- refresh first-party and third-party dependencies, container images, and CI actions across the complete LocalStack stack
- move the Java services to Temurin Java 25 LTS and keep the frontend build on Node.js 24 LTS
- select immutable released application images: backend 3.7.14, frontend 3.7.12, consumer 3.3.6, and Ollama mock 1.0.8
- make the `aitesters` backend/frontend reuse the exact current application artifacts; older application images are rollback-only
- upgrade the production Artemis broker to the supported 2.55 image with an explicit named data volume and document its one-time migration
- synchronize Compose profiles, deployment/monitoring docs, Ansible safeguards, and compatibility verification

## Verification
- source repository CI and tag-release workflows are green for all four application images
- every selected Docker Hub manifest is pinned by digest and publishes linux/amd64 plus linux/arm64
- all modified Compose profiles pass `docker compose config --quiet`
- `python3 scripts/verify-release-images.py --remote`
- `bash scripts/verify-ollama-config.sh`
- released full-stack images pass direct backend/frontend/consumer checks, proxied login/OpenAPI/image checks, and Ollama mock generation locally
- production Artemis preflight reports zero queued or delivering messages; its legacy volume is retained for encrypted backup before deployment