### PR TITLE
Harden release images and production deployment automation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       docker:
-        image: docker:stable
+        image: docker:29.6.2-cli@sha256:be132a9f282288de4afaf63379dff75711fda0147c6b72a9df44e51841402144
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     steps:
@@ -40,6 +40,8 @@ jobs:
     - uses: actions/checkout@v7.0.1
     - name: Verify immutable first-party image set
       run: python3 scripts/verify-release-images.py
+    - name: Verify all remotely pulled images are immutable
+      run: python3 scripts/verify-image-pins.py
 
   verifyLightweight:
     runs-on: ubuntu-latest
@@ -74,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       docker:
-        image: docker:stable
+        image: docker:29.6.2-cli@sha256:be132a9f282288de4afaf63379dff75711fda0147c6b72a9df44e51841402144
         volumes:
           - /var/run/docker.sock:/var/run/docker.sock
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.568.1-lts
+FROM jenkins/jenkins:2.568.1-lts@sha256:f4f65e6cd1405cd889b7f5ac33f9d5cdc2a099de6b87fe8a3933b9c5d53d1d02
 
 USER root
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/zsh
 
-.PHONY: ansible-galaxy ansible-bootstrap ansible-deploy ansible-verify ansible-reset-demo-state ansible-reset-aitesters-state ansible-ping ansible-ssh ansible-edit-vault ansible-tunnel-grafana ansible-tunnel-mailpit ansible-tunnel-all ansible-tunnel-kill-grafana ansible-tunnel-kill-mailpit ansible-tunnel-kill-all
+.PHONY: ansible-galaxy ansible-bootstrap ansible-deploy ansible-verify ansible-cleanup ansible-reset-demo-state ansible-reset-aitesters-state ansible-ping ansible-ssh ansible-edit-vault ansible-tunnel-grafana ansible-tunnel-mailpit ansible-tunnel-all ansible-tunnel-kill-grafana ansible-tunnel-kill-mailpit ansible-tunnel-kill-all sync-release-images
 
 ANSIBLE_VAULT_FILE := .vault_pass
 
@@ -21,6 +21,12 @@ ansible-deploy:
 
 ansible-verify:
 	cd ansible && ansible-playbook playbooks/verify.yml --vault-password-file $(ANSIBLE_VAULT_FILE)
+
+ansible-cleanup:
+	cd ansible && ansible-playbook playbooks/cleanup.yml --vault-password-file $(ANSIBLE_VAULT_FILE)
+
+sync-release-images:
+	python3 scripts/sync-workspace-release-images.py
 
 ansible-reset-demo-state:
 	cd ansible && ansible-playbook playbooks/reset-demo-state.yml --vault-password-file $(ANSIBLE_VAULT_FILE)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Verify the actual Compose path (backend -> adapter -> Docker Model Runner):
 ```bash
 docker compose exec -T backend printenv OLLAMA_BASE_URL
 docker run --rm --network awesome-full-native_my-private-ntwk \
-  curlimages/curl:8.21.0 \
+  curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13 \
   http://ollama-dmr-adapter:11434/api/tags
 docker model ps
 ```
@@ -331,6 +331,7 @@ Server operations:
 make ansible-ssh
 make ansible-deploy
 make ansible-verify
+make ansible-cleanup
 make ansible-reset-demo-state
 make ansible-reset-aitesters-state
 ```
@@ -338,6 +339,7 @@ make ansible-reset-aitesters-state
 - `make ansible-ssh`: open a shell on the VPS using the Ansible/Vault connection settings
 - `make ansible-deploy`: converge the server stack and run post-deploy verification
 - `make ansible-verify`: run health checks without changing deployment state
+- `make ansible-cleanup`: run the checksum- and retention-guarded container cleanup
 - `make ansible-reset-demo-state`: destructively reset Postgres and Mailpit-backed demo state, then redeploy
 - `make ansible-reset-aitesters-state`: recreate only the H2-backed aitesters backend and reseed local demo data
 
@@ -431,6 +433,11 @@ Production hardening in this profile:
 - images are served directly by the gateway
 - the aitesters backend and frontend reuse the exact current application images;
   their sandbox behavior comes from runtime configuration, not stale releases
+- deployment verification checks every running image against its reviewed
+  immutable reference and exercises Artemis-to-consumer-to-Mailpit delivery
+- unused images are pruned only after 30 days; the retired Artemis volume also
+  requires a verified encrypted backup, no attachments, and the same retention
+  period before removal
 
 Use `make ansible-tunnel-grafana` and open `http://localhost:3000` to inspect
 the provisioned **Production Resources** and

--- a/ansible/inventory/group_vars/production/main.yml
+++ b/ansible/inventory/group_vars/production/main.yml
@@ -66,7 +66,7 @@ postgres_backup_remote_target: "{{ backup_remote_target | default('', true) }}"
 postgres_backup_encryption_passphrase: "{{ backup_encryption_passphrase | default('', true) }}"
 postgres_backup_database: testdb
 postgres_backup_user: postgres
-postgres_restore_image: postgres:16.14-bookworm
+postgres_restore_image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
 
 app_copy_paths:
   - nginx
@@ -125,3 +125,10 @@ verify_urls:
     status_code: 404
 verify_retries: 12
 verify_delay_seconds: 10
+
+cleanup_enabled: true
+cleanup_retention_days: 30
+cleanup_schedule: "*-*-* 04:45:00"
+cleanup_unused_images: true
+cleanup_legacy_artemis_volume: 52872b8d5d81bd2a5b8016993442b445559710bb5e8f3bcb92022f0fc5505add
+cleanup_legacy_artemis_backup: /var/backups/awesome-localstack/artemis/artemis-instance-pre-2.55-20260801T105500Z.tgz.enc

--- a/ansible/playbooks/cleanup.yml
+++ b/ansible/playbooks/cleanup.yml
@@ -1,0 +1,7 @@
+- name: Run guarded production container cleanup
+  hosts: production
+  become: true
+  gather_facts: false
+
+  roles:
+    - cleanup

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -8,3 +8,4 @@
     - postgres_backup
     - app
     - verify
+    - cleanup

--- a/ansible/roles/cleanup/tasks/main.yml
+++ b/ansible/roles/cleanup/tasks/main.yml
@@ -1,0 +1,60 @@
+- name: Validate cleanup retention settings
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - cleanup_retention_days | int >= 7
+      - cleanup_legacy_artemis_volume is match('^[0-9a-f]{64}$')
+      - cleanup_legacy_artemis_backup is match('^/.+\.enc$')
+    fail_msg: Cleanup targets must be explicit and retention must be at least seven days.
+  when: cleanup_enabled | bool
+
+- name: Install guarded container cleanup script
+  ansible.builtin.template:
+    src: awesome-container-cleanup.sh.j2
+    dest: /usr/local/sbin/awesome-container-cleanup
+    owner: root
+    group: root
+    mode: "0700"
+  when: cleanup_enabled | bool
+
+- name: Install guarded container cleanup systemd units
+  ansible.builtin.template:
+    src: "{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}"
+    owner: root
+    group: root
+    mode: "0644"
+  loop:
+    - awesome-container-cleanup.service
+    - awesome-container-cleanup.timer
+  register: cleanup_systemd_units
+  when: cleanup_enabled | bool
+
+- name: Reload systemd after installing cleanup units
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+  when:
+    - cleanup_enabled | bool
+    - cleanup_systemd_units is changed
+
+- name: Enable guarded container cleanup timer
+  ansible.builtin.systemd_service:
+    name: awesome-container-cleanup.timer
+    enabled: true
+    state: started
+  when: cleanup_enabled | bool
+
+- name: Run guarded container cleanup after successful verification
+  ansible.builtin.command:
+    argv:
+      - /usr/local/sbin/awesome-container-cleanup
+  register: cleanup_run
+  changed_when: >-
+    'Removed retired Artemis volume' in cleanup_run.stdout
+    or 'Deleted Images:' in cleanup_run.stdout
+  when: cleanup_enabled | bool
+
+- name: Print guarded container cleanup result
+  ansible.builtin.debug:
+    var: cleanup_run.stdout_lines
+  when: cleanup_enabled | bool

--- a/ansible/roles/cleanup/templates/awesome-container-cleanup.service.j2
+++ b/ansible/roles/cleanup/templates/awesome-container-cleanup.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Awesome LocalStack guarded container cleanup
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/awesome-container-cleanup
+User=root
+Group=root

--- a/ansible/roles/cleanup/templates/awesome-container-cleanup.sh.j2
+++ b/ansible/roles/cleanup/templates/awesome-container-cleanup.sh.j2
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+readonly legacy_volume={{ cleanup_legacy_artemis_volume | quote }}
+readonly backup={{ cleanup_legacy_artemis_backup | quote }}
+readonly retention_days={{ cleanup_retention_days | int }}
+readonly retention_seconds=$((retention_days * 24 * 60 * 60))
+readonly retention_hours=$((retention_days * 24))
+
+if docker volume inspect "$legacy_volume" >/dev/null 2>&1; then
+  if [[ ! -f "$backup" || ! -f "${backup}.sha256" ]]; then
+    echo "Refusing to remove $legacy_volume: encrypted backup or checksum is missing." >&2
+    exit 1
+  fi
+
+  (
+    cd "$(dirname "$backup")"
+    sha256sum --check "$(basename "$backup").sha256"
+  )
+
+  backup_age_seconds=$(( $(date +%s) - $(stat -c %Y "$backup") ))
+  if (( backup_age_seconds >= retention_seconds )); then
+    attached_containers="$(docker ps -aq --filter "volume=$legacy_volume")"
+    if [[ -n "$attached_containers" ]]; then
+      echo "Refusing to remove $legacy_volume: it is still attached to a container." >&2
+      exit 1
+    fi
+    docker volume rm "$legacy_volume"
+    echo "Removed retired Artemis volume $legacy_volume after ${retention_days} days."
+  else
+    remaining_days=$(( (retention_seconds - backup_age_seconds + 86399) / 86400 ))
+    echo "Retaining retired Artemis volume $legacy_volume for approximately ${remaining_days} more days."
+  fi
+else
+  echo "Retired Artemis volume $legacy_volume is already absent."
+fi
+
+{% if cleanup_unused_images | bool %}
+docker image prune --all --force --filter "until=${retention_hours}h"
+{% else %}
+echo "Unused-image cleanup is disabled."
+{% endif %}

--- a/ansible/roles/cleanup/templates/awesome-container-cleanup.timer.j2
+++ b/ansible/roles/cleanup/templates/awesome-container-cleanup.timer.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run Awesome LocalStack guarded container cleanup
+
+[Timer]
+OnCalendar={{ cleanup_schedule }}
+Persistent=true
+RandomizedDelaySec=15m
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/verify/tasks/main.yml
+++ b/ansible/roles/verify/tasks/main.yml
@@ -9,6 +9,219 @@
   ansible.builtin.debug:
     var: compose_ps.stdout_lines
 
+- name: Read the resolved production Compose configuration
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - config
+      - --format
+      - json
+    chdir: "{{ app_dir }}"
+  register: verify_compose_config_response
+  changed_when: false
+
+- name: Record expected production services and image references
+  ansible.builtin.set_fact:
+    verify_compose_config: "{{ verify_compose_config_response.stdout | from_json }}"
+    verify_expected_services: >-
+      {{
+        (verify_compose_config_response.stdout | from_json).services.keys()
+        | list
+        | sort
+      }}
+
+- name: Read running production services
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - ps
+      - --services
+      - --status
+      - running
+    chdir: "{{ app_dir }}"
+  register: verify_running_services_response
+  changed_when: false
+
+- name: Verify every production service is running
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - >-
+        verify_expected_services
+        | difference(verify_running_services_response.stdout_lines)
+        | length == 0
+      - >-
+        verify_running_services_response.stdout_lines
+        | difference(verify_expected_services)
+        | length == 0
+    fail_msg: >-
+      Expected running services {{ verify_expected_services }}, got
+      {{ verify_running_services_response.stdout_lines }}
+
+- name: Resolve running production container IDs
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - ps
+      - -q
+      - "{{ item }}"
+    chdir: "{{ app_dir }}"
+  loop: "{{ verify_expected_services }}"
+  register: verify_running_container_id_results
+  changed_when: false
+
+- name: Resolve running container image IDs
+  ansible.builtin.command:
+    argv:
+      - docker
+      - inspect
+      - "--format={{ '{{.Image}}' }}"
+      - "{{ item.stdout }}"
+  loop: "{{ verify_running_container_id_results.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+  register: verify_running_image_id_results
+  changed_when: false
+
+- name: Resolve reviewed image-reference IDs
+  ansible.builtin.command:
+    argv:
+      - docker
+      - image
+      - inspect
+      - "--format={{ '{{.Id}}' }}"
+      - "{{ verify_compose_config.services[item].image }}"
+  loop: "{{ verify_expected_services }}"
+  register: verify_expected_image_id_results
+  changed_when: false
+
+- name: Verify running containers use the reviewed image references
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - verify_running_image_id_results.results[verify_image_index].stdout == item.stdout
+    fail_msg: >-
+      Service {{ item.item }} is running image ID
+      {{ verify_running_image_id_results.results[verify_image_index].stdout }},
+      but {{ verify_compose_config.services[item.item].image }} resolves to
+      {{ item.stdout }}
+  loop: "{{ verify_expected_image_id_results.results }}"
+  loop_control:
+    index_var: verify_image_index
+    label: "{{ item.item }}"
+
+- name: Create a unique JMS delivery-contract identifier
+  ansible.builtin.command:
+    argv:
+      - date
+      - +%s%N
+  register: verify_jms_contract_id
+  changed_when: false
+
+- name: Record the JMS delivery-contract payload
+  ansible.builtin.set_fact:
+    verify_jms_contract_subject: >-
+      Awesome deployment JMS contract {{ verify_jms_contract_id.stdout }}
+    verify_jms_contract_message:
+      to: delivery-contract@example.test
+      subject: >-
+        Awesome deployment JMS contract {{ verify_jms_contract_id.stdout }}
+      message: Artemis to consumer to Mailpit production verification
+      template: GENERIC
+      properties: {}
+
+- name: Publish the JMS delivery-contract message
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - activemq
+      - /var/lib/artemis-instance/bin/artemis
+      - producer
+      - --url
+      - tcp://localhost:61616
+      - --user
+      - "{{ artemis_username }}"
+      - --password
+      - "{{ artemis_password }}"
+      - --destination
+      - queue://email
+      - --message-count
+      - "1"
+      - --message
+      - "{{ verify_jms_contract_message | to_json }}"
+      - --properties
+      - '[{"type":"string","key":"_awesome_","value":"EmailDTO"}]'
+      - --silent
+    chdir: "{{ app_dir }}"
+  register: verify_jms_publish
+  changed_when: true
+  no_log: true
+  until: verify_jms_publish.rc == 0
+  retries: "{{ verify_retries }}"
+  delay: "{{ verify_delay_seconds }}"
+
+- name: Wait for the consumer to deliver the contract email to Mailpit
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - gateway
+      - curl
+      - -fsS
+      - http://mailpit:8025/api/v1/messages
+    chdir: "{{ app_dir }}"
+  register: verify_jms_mailpit_response
+  changed_when: false
+  until:
+    - verify_jms_mailpit_response.rc == 0
+    - >-
+      verify_jms_contract_subject in
+      (
+        (verify_jms_mailpit_response.stdout | from_json).messages
+        | map(attribute='Subject')
+        | list
+      )
+  retries: "{{ verify_retries }}"
+  delay: "{{ verify_delay_seconds }}"
+
+- name: Record the delivered JMS contract email
+  ansible.builtin.set_fact:
+    verify_jms_delivered_message: >-
+      {{
+        (verify_jms_mailpit_response.stdout | from_json).messages
+        | selectattr('Subject', 'equalto', verify_jms_contract_subject)
+        | first
+      }}
+
+- name: Verify the JMS contract email recipient
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - >-
+        'delivery-contract@example.test' in
+        (verify_jms_delivered_message.To | map(attribute='Address') | list)
+    fail_msg: >-
+      JMS contract email reached Mailpit with unexpected recipients:
+      {{ verify_jms_delivered_message.To }}
+
 - name: Verify internal monitoring endpoints
   ansible.builtin.command:
     argv:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -286,7 +286,7 @@ services:
       - my-private-ntwk
 
   postgres:
-    image: postgres:16.14-bookworm
+    image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
     restart: unless-stopped
     logging: *default-logging
     environment:
@@ -340,7 +340,7 @@ services:
       - my-private-ntwk
 
   mailpit:
-    image: axllent/mailpit:v1.30.0
+    image: axllent/mailpit:v1.30.0@sha256:0059ef81e492a7192af3816281eed6859eb078bd7bdc58b76757c13e10e53a7d
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       - my-private-ntwk
 
   keycloak-init:
-    image: curlimages/curl:8.21.0
+    image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
     entrypoint: ["/bin/sh", "/init/init-mock-users.sh"]
     volumes:
       - ./keycloak/init-mock-users.sh:/init/init-mock-users.sh:ro
@@ -119,7 +119,7 @@ services:
       - my-private-ntwk
 
   postgres:
-    image: postgres:16.14-bookworm
+    image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
     restart: always
     environment:
       POSTGRES_DB: testdb
@@ -182,7 +182,7 @@ services:
       - my-private-ntwk
 
   mailpit:
-    image: axllent/mailpit:v1.30.0
+    image: axllent/mailpit:v1.30.0@sha256:0059ef81e492a7192af3816281eed6859eb078bd7bdc58b76757c13e10e53a7d
     restart: always
     environment:
       MP_DISABLE_VERSION_CHECK: "true"

--- a/docs/ANSIBLE.md
+++ b/docs/ANSIBLE.md
@@ -34,6 +34,7 @@ ansible/
     postgres_backup/
     app/
     verify/
+    cleanup/
   requirements.yml
 Makefile
 ```
@@ -74,6 +75,12 @@ Run verification only:
 
 ```bash
 make ansible-verify
+```
+
+Run the guarded retention cleanup independently:
+
+```bash
+make ansible-cleanup
 ```
 
 Reset the public demo data store and redeploy from a clean baseline:
@@ -117,7 +124,7 @@ ansible-vault encrypt inventory/group_vars/production/vault.yml --vault-password
 
 `deploy.yml` is the normal operational entrypoint.
 
-It performs four steps in order:
+It performs five steps in order:
 
 1. Runs the guarded `swap` role. It can converge a 1 GiB emergency swap file
    and low swappiness on capable hosts; it reports a tracked reason and makes no
@@ -127,6 +134,7 @@ It performs four steps in order:
    `/opt/awesome-localstack`.
 4. Runs the `verify` role to make sure the deployed stack is actually
    reachable.
+5. Runs the guarded `cleanup` role only after verification succeeds.
 
 This is intentional. In this project, a deploy that leaves the gateway returning `502` is a failed deploy, not a successful deploy with a separate follow-up check.
 
@@ -167,6 +175,10 @@ The `verify` role remains separate so it can still be run on demand, but it is a
 The role checks:
 
 - `docker compose ps`
+- every expected service is running the exact image ID resolved from the
+  reviewed immutable Compose reference
+- an Artemis message is consumed and delivered to Mailpit as a uniquely named
+  email
 - `http://127.0.0.1/login`
 - `http://127.0.0.1/v3/api-docs`
 - `http://127.0.0.1/images/iphone.png`
@@ -198,6 +210,20 @@ For that reason, HTTP verification uses retries and delay rather than failing im
 - `postgres_backup`: encrypted backups, restore checks, and the pre-deploy backup
 - `app`: file sync, runtime env rendering, Compose convergence
 - `verify`: operational checks after deploy
+- `cleanup`: checksum- and age-guarded retirement of the legacy Artemis volume
+  plus pruning of unused images older than the retention window
+
+### Retention-based container cleanup
+
+The cleanup role installs a daily systemd timer and also runs once after a
+successful deployment verification. The production retention window is 30
+days. It removes only unused images older than that window.
+
+The retired Artemis anonymous volume has an additional guard: the exact
+encrypted backup and its checksum sidecar must exist and verify successfully,
+the backup must be at least 30 days old, and no container may still reference
+the volume. Until every condition passes, the volume is retained. The encrypted
+backup is not deleted by this role.
 
 ## Vault Workflow
 

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -72,6 +72,10 @@ Previous application releases remain rollback references only.
 
 Static pin verification runs in normal LocalStack CI. `.github/workflows/verify-release-images.yml` performs the registry check weekly and on manual request.
 
+`scripts/verify-image-pins.py` extends the rule to every remotely pulled image
+in all Compose profiles, the Jenkins Dockerfile, CI service containers, and the
+PostgreSQL restore tool. Locally built `:local` images are the only exception.
+
 ## Release sequence
 
 1. Merge a green source change to that repository's default branch.
@@ -79,8 +83,14 @@ Static pin verification runs in normal LocalStack CI. `.github/workflows/verify-
 3. Create the matching signed or annotated `vX.Y.Z` tag, or run an explicit candidate from the intended commit.
 4. Wait for both registry publications and copy the Docker Hub manifest digest from the workflow summary or `docker buildx imagetools inspect`.
 5. Update the relevant `tag@sha256` references in the LocalStack profiles and the compatibility table.
-6. Run all Compose configuration checks and `python3 scripts/verify-release-images.py --remote`.
-7. Run the affected direct-service, gateway, lightweight, and full gates.
-8. Merge the LocalStack release PR, create an encrypted production backup when stateful services are affected, and deploy through Ansible.
+6. Run `make sync-release-images` from this repository to propagate backend,
+   frontend, and Ollama-mock references into the sibling development Compose
+   files. The command fails if the expected workspace repositories or reference
+   shapes are missing and validates each changed Compose file.
+7. Run all Compose configuration checks,
+   `python3 scripts/verify-image-pins.py`, and
+   `python3 scripts/verify-release-images.py --remote`.
+8. Run the affected direct-service, gateway, lightweight, and full gates.
+9. Merge the LocalStack release PR, create an encrypted production backup when stateful services are affected, and deploy through Ansible.
 
 An application release does not require rebuilding unchanged applications. It does require retaining their known-good immutable references in the reviewed compatibility set. Backward compatibility is maintained for persisted data and external contracts where required; the deployment does not keep stale application images running as compatibility variants.

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   keycloak-init:
-    image: curlimages/curl:8.21.0
+    image: curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13
     entrypoint: ["/bin/sh", "/init/init-mock-users.sh"]
     volumes:
       - ./keycloak/init-mock-users.sh:/init/init-mock-users.sh:ro

--- a/scripts/sync-workspace-release-images.py
+++ b/scripts/sync-workspace-release-images.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Propagate the reviewed application image set to sibling development repos."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMAGE_PATTERN = r"slawekradzyminski/{repository}:[^\s}}]+"
+
+
+def release_images() -> dict[str, str]:
+    result = subprocess.run(
+        ["docker", "compose", "-f", "docker-compose.server.yml", "config", "--format", "json"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    services = json.loads(result.stdout)["services"]
+    return {
+        service: services[service]["image"]
+        for service in ("backend", "frontend", "ollama-mock")
+    }
+
+
+def update_reference(path: Path, repository: str, image: str, check: bool) -> bool:
+    original = path.read_text()
+    updated, replacements = re.subn(
+        IMAGE_PATTERN.format(repository=re.escape(repository)),
+        image,
+        original,
+    )
+    if replacements != 1:
+        raise RuntimeError(
+            f"Expected one {repository} reference in {path}, found {replacements}"
+        )
+    if updated == original:
+        print(f"current: {path}")
+        return False
+    if check:
+        print(f"stale:   {path}")
+    else:
+        path.write_text(updated)
+        print(f"updated: {path}")
+    return True
+
+
+def validate_compose(repository: Path) -> None:
+    subprocess.run(
+        ["docker", "compose", "config", "--quiet"],
+        cwd=repository,
+        check=True,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", action="store_true", help="report drift without editing")
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        default=ROOT.parent,
+        help="directory containing the sibling repositories",
+    )
+    args = parser.parse_args()
+
+    images = release_images()
+    targets = (
+        (args.workspace_root / "test-secure-backend", "frontend", images["frontend"]),
+        (args.workspace_root / "vite-react-frontend", "backend", images["backend"]),
+        (args.workspace_root / "vite-react-frontend", "ollama-mock", images["ollama-mock"]),
+    )
+
+    changed = False
+    touched_repositories: set[Path] = set()
+    for repository, image_repository, image in targets:
+        compose = repository / "docker-compose.yml"
+        if not compose.is_file():
+            raise FileNotFoundError(f"Missing sibling Compose file: {compose}")
+        changed |= update_reference(compose, image_repository, image, args.check)
+        touched_repositories.add(repository)
+
+    if args.check and changed:
+        print("Workspace development Compose references are stale", file=sys.stderr)
+        return 1
+
+    for repository in sorted(touched_repositories):
+        validate_compose(repository)
+    print("Workspace development Compose references match the reviewed release set")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-edge-proxy.sh
+++ b/scripts/verify-edge-proxy.sh
@@ -33,7 +33,7 @@ docker run --detach --rm \
 response=""
 for _ in $(seq 1 20); do
   if response="$(
-    docker run --rm --network "${network}" curlimages/curl:8.21.0 \
+    docker run --rm --network "${network}" curlimages/curl:8.21.0@sha256:7c12af72ceb38b7432ab85e1a265cff6ae58e06f95539d539b654f2cfa64bb13 \
       --fail \
       --silent \
       --show-error \

--- a/scripts/verify-image-pins.py
+++ b/scripts/verify-image-pins.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Require immutable references for every remotely pulled repository image."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PINNED_IMAGE = re.compile(r"^[^@\s]+:[^@\s]+@sha256:[0-9a-f]{64}$")
+COMPOSE_PROFILES = (
+    ("docker-compose.yml",),
+    ("docker-compose.yml", "docker-compose.model-mock.yml"),
+    ("lightweight-docker-compose.yml",),
+    ("docker-compose.server.yml",),
+)
+
+
+def resolved_services(files: tuple[str, ...]) -> dict[str, dict[str, object]]:
+    command = ["docker", "compose"]
+    for filename in files:
+        command.extend(("-f", filename))
+    command.extend(("config", "--format", "json"))
+    result = subprocess.run(
+        command,
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)["services"]
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for files in COMPOSE_PROFILES:
+        profile = "+".join(files)
+        for service, config in resolved_services(files).items():
+            image = str(config.get("image", ""))
+            local_build = bool(config.get("build")) and image.endswith(":local")
+            if not local_build and not PINNED_IMAGE.fullmatch(image):
+                failures.append(
+                    f"{profile} service {service} is not pinned by digest: {image}"
+                )
+
+    dockerfile = ROOT / "Dockerfile"
+    for line_number, line in enumerate(dockerfile.read_text().splitlines(), start=1):
+        if not line.startswith("FROM "):
+            continue
+        tokens = line.split()
+        image = tokens[1]
+        if image.startswith("--platform="):
+            image = tokens[2]
+        if not PINNED_IMAGE.fullmatch(image):
+            failures.append(f"Dockerfile:{line_number} is not pinned by digest: {image}")
+
+    workflow_image = re.compile(r"^\s+image:\s+(\S+)\s*$")
+    for workflow in sorted((ROOT / ".github" / "workflows").glob("*.yml")):
+        for line_number, line in enumerate(workflow.read_text().splitlines(), start=1):
+            match = workflow_image.match(line)
+            if match and not PINNED_IMAGE.fullmatch(match.group(1)):
+                failures.append(
+                    f"{workflow.relative_to(ROOT)}:{line_number} is not pinned by digest: "
+                    f"{match.group(1)}"
+                )
+
+    inventory = (
+        ROOT / "ansible/inventory/group_vars/production/main.yml"
+    ).read_text()
+    restore_match = re.search(r"^postgres_restore_image:\s*(\S+)$", inventory, re.M)
+    restore_image = restore_match.group(1) if restore_match else ""
+    if not PINNED_IMAGE.fullmatch(restore_image):
+        failures.append(f"postgres_restore_image is not pinned by digest: {restore_image}")
+
+    if failures:
+        for failure in failures:
+            print(f"ERROR: {failure}", file=sys.stderr)
+        return 1
+
+    print("Verified immutable image pins for Compose, CI, Dockerfile, and restore tooling")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- pin remaining Compose, CI, Dockerfile, and restore images by digest and enforce the policy in CI
- verify running production image IDs and Artemis-to-consumer-to-Mailpit delivery during deployment
- propagate reviewed release refs to sibling development Compose files
- add guarded 30-day legacy-volume and unused-image cleanup

## Verification
- all Compose profiles validate
- image pin/release scripts pass
- Ansible syntax checks pass
- live production verification passes, including image IDs and JMS delivery