### PR TITLE
Manage PostgreSQL credentials with Ansible Vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,8 @@ Production hardening in this profile:
 - Mailpit SMTP is not published
 - Mailpit API is not published
 - ActiveMQ is internal-only
+- the production PostgreSQL password is supplied by Ansible Vault and is not
+  stored in Compose
 - consumer metrics are internal-only
 - Node Exporter, cAdvisor, Blackbox Exporter, Prometheus, and Alertmanager are internal-only
 - Prometheus history is persisted and bounded by 30-day and 5 GB retention limits

--- a/ansible/inventory/group_vars/production/main.yml
+++ b/ansible/inventory/group_vars/production/main.yml
@@ -89,6 +89,8 @@ alertmanager_config_files:
   - alertmanager/templates/telegram.tmpl
 
 app_runtime_env:
+  POSTGRES_PASSWORD: "{{ postgres_password | default('', true) }}"
+  SPRING_DATASOURCE_PASSWORD: "{{ postgres_password | default('', true) }}"
   GF_SECURITY_ADMIN_PASSWORD: "{{ grafana_admin_password | default('', true) }}"
   ARTEMIS_USER: "{{ artemis_username | default('', true) }}"
   ARTEMIS_PASSWORD: "{{ artemis_password | default('', true) }}"

--- a/ansible/inventory/group_vars/production/vault.yml.example
+++ b/ansible/inventory/group_vars/production/vault.yml.example
@@ -15,6 +15,9 @@ alertmanager_telegram_bot_token: replace-with-the-botfather-token
 alertmanager_telegram_chat_id: "123456789"
 artemis_username: awesome-broker
 artemis_password: replace-with-a-strong-broker-secret
+# Used by both the PostgreSQL container and the backend datasource. The
+# deployment reconciles an existing postgres role before recreating services.
+postgres_password: replace-with-a-strong-database-secret
 app_bootstrap_admin_enabled: "true"
 app_bootstrap_admin_username: admin
 app_bootstrap_admin_password: replace-with-a-16-plus-character-secret

--- a/ansible/roles/app/tasks/main.yml
+++ b/ansible/roles/app/tasks/main.yml
@@ -36,6 +36,17 @@
       must be configured in Ansible Vault
   no_log: true
 
+- name: Validate PostgreSQL credentials
+  ansible.builtin.assert:
+    that:
+      - (postgres_password | default('', true) | string | length) >= 16
+      - (postgres_password | default('', true) | string) != 'postgres'
+    fail_msg: >-
+      postgres_password must be a non-default value of at least 16 characters
+      configured in Ansible Vault
+    quiet: true
+  no_log: true
+
 - name: Read deployed Prometheus configuration checksums
   ansible.builtin.stat:
     path: "{{ app_dir }}/{{ prometheus_config_file }}"
@@ -247,6 +258,100 @@
     mode: "0400"
   register: alertmanager_telegram_chat_id_file
   no_log: true
+
+- name: Check whether PostgreSQL is already running
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - ps
+      - -q
+      - postgres
+    chdir: "{{ app_dir }}"
+  register: app_postgres_container
+  changed_when: false
+  failed_when: false
+
+- name: Check whether PostgreSQL accepts the Vault-managed password
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - -e
+      - PGPASSWORD
+      - postgres
+      - psql
+      - --host=postgres
+      - --username=postgres
+      - --dbname=postgres
+      - --tuples-only
+      - --no-align
+      - --command=SELECT 1
+    chdir: "{{ app_dir }}"
+  environment:
+    PGPASSWORD: "{{ postgres_password }}"
+  register: postgres_vault_password_check
+  changed_when: false
+  failed_when: false
+  no_log: true
+  when: app_postgres_container.stdout | trim | length > 0
+
+- name: Reconcile the existing PostgreSQL role password with Ansible Vault
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - postgres
+      - psql
+      - --username=postgres
+      - --dbname=postgres
+      - --set=ON_ERROR_STOP=1
+    chdir: "{{ app_dir }}"
+    stdin: >-
+      ALTER ROLE postgres WITH PASSWORD
+      '{{ postgres_password | replace("'", "''") }}';
+  register: postgres_password_reconciliation
+  changed_when: true
+  no_log: true
+  when:
+    - app_postgres_container.stdout | trim | length > 0
+    - postgres_vault_password_check.rc != 0
+
+- name: Verify the reconciled PostgreSQL password
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - -e
+      - PGPASSWORD
+      - postgres
+      - psql
+      - --host=postgres
+      - --username=postgres
+      - --dbname=postgres
+      - --tuples-only
+      - --no-align
+      - --command=SELECT 1
+    chdir: "{{ app_dir }}"
+  environment:
+    PGPASSWORD: "{{ postgres_password }}"
+  changed_when: false
+  no_log: true
+  when: postgres_password_reconciliation is changed
 
 - name: Deploy Docker Compose stack
   community.docker.docker_compose_v2:

--- a/ansible/roles/verify/tasks/main.yml
+++ b/ansible/roles/verify/tasks/main.yml
@@ -22,6 +22,7 @@
     chdir: "{{ app_dir }}"
   register: verify_compose_config_response
   changed_when: false
+  no_log: true
 
 - name: Record expected production services and image references
   ansible.builtin.set_fact:
@@ -32,6 +33,7 @@
         | list
         | sort
       }}
+  no_log: true
 
 - name: Read running production services
   ansible.builtin.command:
@@ -63,6 +65,32 @@
     fail_msg: >-
       Expected running services {{ verify_expected_services }}, got
       {{ verify_running_services_response.stdout_lines }}
+
+- name: Verify PostgreSQL authentication with the Vault-managed password
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - -e
+      - PGPASSWORD
+      - postgres
+      - psql
+      - --host=postgres
+      - --username=postgres
+      - --dbname=postgres
+      - --tuples-only
+      - --no-align
+      - --command=SELECT 1
+    chdir: "{{ app_dir }}"
+  environment:
+    PGPASSWORD: "{{ postgres_password }}"
+  register: verify_postgres_vault_password
+  changed_when: false
+  no_log: true
 
 - name: Resolve running production container IDs
   ansible.builtin.command:

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -21,7 +21,6 @@ services:
       SPRING_ARTEMIS_BROKER_URL: tcp://activemq:61616
       SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/testdb
       SPRING_DATASOURCE_USERNAME: postgres
-      SPRING_DATASOURCE_PASSWORD: postgres
       SERVER_FORWARD_HEADERS_STRATEGY: framework
       SECURITY_RATE_LIMIT_ENABLED: "true"
       SECURITY_RATE_LIMIT_TRUST_FORWARDED_HEADERS: "true"
@@ -289,10 +288,12 @@ services:
     image: postgres:16.14-bookworm@sha256:92620daddcd947f8d5ab5ba66e848702fe443d87fed30c4cea8e389fd78dfc55
     restart: unless-stopped
     logging: *default-logging
+    env_file:
+      - path: .env.runtime
+        required: false
     environment:
       POSTGRES_DB: testdb
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:

--- a/docs/ANSIBLE.md
+++ b/docs/ANSIBLE.md
@@ -130,8 +130,9 @@ It performs five steps in order:
    and low swappiness on capable hosts; it reports a tracked reason and makes no
    swap changes on the current MIKR.US LXC host.
 2. Runs the `postgres_backup` role and creates the encrypted pre-deploy backup.
-3. Runs the `app` role to converge files and Docker Compose state in
-   `/opt/awesome-localstack`.
+3. Runs the `app` role to reconcile the existing PostgreSQL role with the
+   Vault-managed password, render the protected runtime environment, and
+   converge files and Docker Compose state in `/opt/awesome-localstack`.
 4. Runs the `verify` role to make sure the deployed stack is actually
    reachable.
 5. Runs the guarded `cleanup` role only after verification succeeds.
@@ -238,6 +239,7 @@ The local production Vault file stores values such as:
 - `alertmanager_telegram_chat_id`
 - `artemis_username`
 - `artemis_password`
+- `postgres_password`
 - `app_bootstrap_admin_enabled`
 - `app_bootstrap_admin_username`
 - `app_bootstrap_admin_password`


### PR DESCRIPTION
## What changed

- remove the committed production PostgreSQL password from the server Compose profile
- provide `POSTGRES_PASSWORD` and `SPRING_DATASOURCE_PASSWORD` through the protected Ansible-rendered runtime environment
- add a required `postgres_password` value to the encrypted production Vault contract
- reconcile an existing PostgreSQL role password before service recreation, only when the desired Vault password is not already accepted
- verify Vault-managed PostgreSQL authentication after reconciliation and during normal post-deploy verification
- suppress resolved Compose configuration from Ansible logs because it contains runtime secrets
- document the deployment behavior

## Why

The production profile used the default `postgres` password in tracked Compose configuration. Merely changing the container environment is insufficient for an existing PostgreSQL data volume because the official image applies `POSTGRES_PASSWORD` only during initialization. The deployment now handles both new and existing volumes safely.

## Deployment behavior

The encrypted local production Vault already contains a generated strong `postgres_password`. During deployment, the existing encrypted backup runs first. The app role then tests the Vault password over the Docker network, reconciles the role only if necessary, deploys the updated services, and the verify role confirms authenticated database access and the existing application contracts.

## Validation

- `docker compose -f docker-compose.server.yml config --quiet`
- Ansible syntax checks for `deploy.yml` and `verify.yml`
- immutable image pin and release-set checks
- edge-proxy and Ollama configuration checks
- 12 Docker Model Runner adapter tests
- isolated PostgreSQL 16.14 migration test proving rejection before reconciliation and acceptance afterward