### PR TITLE
Document mutation testing and deploy reviewed releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ For the local SSO flow, standard-login comparison, and local credentials, see [d
 For repository-owned image publishing and the complete four-image compatibility
 set, see [docs/CONTAINER_RELEASES.md](docs/CONTAINER_RELEASES.md).
 
+For the empirical mutation-testing results and the workflow used by coding
+agents, see [docs/MUTATION_TESTING_AI_STUDY.md](docs/MUTATION_TESTING_AI_STUDY.md)
+and [docs/MUTATION_TESTING_AGENT_PLAYBOOK.md](docs/MUTATION_TESTING_AGENT_PLAYBOOK.md).
+
 Each main compose file now has its own fixed Compose project name. That means switching between `lightweight`, `full`, and `server` should no longer produce normal orphan warnings just because the profiles define different services.
 
 This does not mean the profiles can run side by side on the same machine. `lightweight` and `full` still publish overlapping host ports such as `8081` and `11434`, so stop one profile before starting the other.

--- a/docker-compose.model-mock.yml
+++ b/docker-compose.model-mock.yml
@@ -14,7 +14,7 @@ services:
       - dmr
 
   ollama:
-    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
+    image: slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab
     restart: unless-stopped
     ports:
       - "11434:11434"

--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
+    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
     restart: unless-stopped
     hostname: backend
     logging: *default-logging
@@ -61,7 +61,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
+    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   aitesters-backend:
-    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
+    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
     restart: unless-stopped
     hostname: aitesters-backend
     logging: *default-logging
@@ -110,7 +110,7 @@ services:
       - my-private-ntwk
 
   aitesters-frontend:
-    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
+    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -356,7 +356,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.6@sha256:a4f980d7c88ce7ec628e58bfeeed8f9390b28251ae198dbd179eac6e7c4f8b89
+    image: slawekradzyminski/consumer:3.3.7@sha256:545e2a091318e04d738915f19ba8a22220f943db108f76a9a31b296ca2cf1d61
     restart: unless-stopped
     logging: *default-logging
     env_file:
@@ -381,7 +381,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
+    image: slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab
     restart: unless-stopped
     logging: *default-logging
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full-native
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
+    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
     restart: always
     expose:
       - "4001"
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
+    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
     restart: always
     expose:
       - "80"
@@ -194,7 +194,7 @@ services:
       - my-private-ntwk
 
   consumer:
-    image: slawekradzyminski/consumer:3.3.6@sha256:a4f980d7c88ce7ec628e58bfeeed8f9390b28251ae198dbd179eac6e7c4f8b89
+    image: slawekradzyminski/consumer:3.3.7@sha256:545e2a091318e04d738915f19ba8a22220f943db108f76a9a31b296ca2cf1d61
     restart: always
     ports:
       - "4002:4002"

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -46,10 +46,10 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 
 | Service | Immutable image |
 | --- | --- |
-| Backend | `slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7` |
-| Frontend | `slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112` |
-| Consumer | `slawekradzyminski/consumer:3.3.6@sha256:a4f980d7c88ce7ec628e58bfeeed8f9390b28251ae198dbd179eac6e7c4f8b89` |
-| Ollama mock | `slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e` |
+| Backend | `slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0` |
+| Frontend | `slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea` |
+| Consumer | `slawekradzyminski/consumer:3.3.7@sha256:545e2a091318e04d738915f19ba8a22220f943db108f76a9a31b296ca2cf1d61` |
+| Ollama mock | `slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab` |
 
 ## LocalStack compatibility gate
 

--- a/docs/MUTATION_TESTING_AGENT_PLAYBOOK.md
+++ b/docs/MUTATION_TESTING_AGENT_PLAYBOOK.md
@@ -1,0 +1,136 @@
+# Mutation Testing Agent Playbook
+
+## The rule
+
+Mutation testing is a feedback sensor for an implementation agent, not the
+first command in its edit loop and not an autonomous verdict. Run normal tests
+first. Then use a small mutation scope to ask whether those tests would detect
+plausible behavioral damage.
+
+## Installed commands
+
+| Repository | Command | Permanent scope |
+| --- | --- | --- |
+| `test-secure-backend` | `./mvnw -Pmutation-testing test-compile pitest:mutationCoverage` | ten high-value service, auth, traffic, and LLM-handler classes |
+| `vite-react-frontend` | `npm run test:mutation` | runtime configuration, SSE, and SSO |
+| `jms-email-consumer` | `./mvnw -Pmutation-testing test-compile pitest:mutationCoverage` | JMS configuration, consumer, and renderer |
+| `ollama-mock` | `./mvnw -Pmutation-testing test-compile pitest:mutationCoverage` | service and token-stream utilities |
+
+PIT writes HTML/XML under `target/pit-reports`. Stryker writes JSON/HTML under
+`reports/mutation`.
+
+## When to run it
+
+1. During ordinary editing, run the smallest relevant unit tests. Do not run
+   mutation testing after every save.
+2. After the unit suite is green, run the targeted mutation command when the
+   change touches the configured scope or its tests.
+3. Before an agent hands off a pull request, classify every new survivor on a
+   changed high-risk line.
+4. Run a wider package scope nightly and a broader trend run weekly. These jobs
+   should not block the fast developer loop.
+
+Skip the mutation run for documentation, formatting, generated assets, and
+changes outside the configured production scope unless the scope itself needs
+to be expanded.
+
+## How an agent should process a report
+
+For each result on a changed or security-critical line:
+
+1. `NO_COVERAGE` / `NoCoverage`: decide whether the execution path is part of
+   the supported contract. If yes, add a test that reaches it. If no, record why
+   it is outside the selected test level.
+2. `SURVIVED` / `Survived`: state the behavioral change introduced by the
+   mutant. Write the missing expectation from the requirement or public
+   contract, not from the implementation syntax.
+3. Run the new test against the original code and rerun mutation testing. The
+   work is complete only if the original remains green and the intended mutant
+   is killed.
+4. Classify leftovers as meaningful missing oracle, equivalent/unobservable,
+   diagnostic-only, runner/instrumentation anomaly, or intentionally out of
+   scope. Never add a brittle assertion merely to move the percentage.
+5. If a survivor contradicts an existing direct assertion, rerun only that
+   mutant or line with conservative coverage analysis. Confirm that the mutant
+   is actually active before asking the agent to manufacture another test.
+6. For time, retries, and concurrency, prefer virtual clocks and controlled
+   schedulers. A mutation that exposes an untestable clock is often design
+   feedback, not a reason to add a real sleep.
+
+The agent should report mutant location, mutation, risk, test added, and
+before/after status. It should not change production behavior solely to silence
+an equivalent mutant.
+
+## Quality gates
+
+Start with a semantic pull-request gate:
+
+- no new unclassified survivors on changed lines;
+- zero accepted meaningful survivors in authentication, authorization, token
+  generation, money, order state, sanitization, and messaging contracts;
+- no decrease in the target's mutation score or covered-code test strength
+  without an explicit explanation.
+
+Do not turn a global 80% score into the first gate. The current baselines have
+different reachability profiles:
+
+| Target | Total score | Covered-code strength |
+| --- | ---: | ---: |
+| Backend | 89% | 100% |
+| Frontend | 82.41% | 84.33% |
+| Consumer | 100% | 100% |
+| Mock | 87% | 96% |
+
+After two to four weeks of stable runs, a numeric safety floor can sit just
+below these baselines—for example 88%, 81%, 95%, and 86% total score
+respectively—while the ratchet and high-risk semantic gate remain authoritative.
+Raise floors gradually as uncovered supported paths are added. Do not lower a
+floor to make a pull request pass.
+
+## Suggested agent instruction
+
+Use this in a task prompt when the change intersects a configured scope:
+
+> Run the normal tests first, then the repository's targeted mutation command.
+> Analyze only mutants in changed or high-risk behavior. Separate no-coverage
+> paths from surviving assertions. For each meaningful survivor, describe the
+> behavioral damage, add a contract-level test that fails on that mutant and
+> passes on the original, rerun the mutation command, and report the before/after
+> result. Classify equivalent, diagnostic, runner-anomaly, and intentionally
+> out-of-scope mutants; validate suspicious survivors with a narrow rerun. Use
+> virtual time for temporal behavior. Do not game the score or alter production
+> code only to kill a mutant.
+
+## Two layers for agent-heavy development
+
+Keep rule-based and AI-generated mutants as separate layers:
+
+1. PIT/Stryker is the deterministic PR feedback loop. Its survivors can guide
+   persistent tests and support a stable ratchet.
+2. Concern-specific LLM mutants are a sampled adversarial evaluation for
+   nightly, high-risk, or just-in-time runs. They may better resemble semantic
+   bugs, but require compilation, duplication, and equivalence filtering.
+
+Always give the test-writing agent the requirement or protected concern as well
+as the mutant. A mutant is a counterexample candidate, not the source of truth.
+Persist tests that express stable business, security, protocol, or timing
+contracts. Ephemeral tests are reasonable for one-off speculative mutants whose
+only purpose is to assess a particular change.
+
+The semantic layer is executable in this workspace:
+
+```bash
+python3 experiments/llm-mutation/run_lab.py \
+  --output experiments/llm-mutation/results/run.json
+```
+
+For every LLM-generated patch, require: a stated violated contract, clean patch
+application, successful compilation, and a reviewer decision that the behavior
+is supported and observably wrong. Compiler failures are invalid mutants, not
+kills. Freeze the patch set before asking an agent to strengthen tests, and do
+not regenerate easier mutants after seeing results.
+
+The same instruction is now summarized in each repository's `AGENTS.md`, so an
+agent operating there can discover the workflow without a bespoke prompt. The
+explicit prompt is still useful for high-risk changes or when mutation analysis
+is the main purpose of the task.

--- a/docs/MUTATION_TESTING_AI_STUDY.md
+++ b/docs/MUTATION_TESTING_AI_STUDY.md
@@ -1,0 +1,470 @@
+# Mutation Testing for Agent-Written Code
+
+Empirical study run on 2026-08-02 against four repositories in the Awesome
+Testing stack.
+
+## Implementation follow-up
+
+The proof of concept was subsequently installed in the four repositories. The
+production code was not changed: the mutation reports exposed missing proof in
+the tests, and the follow-up strengthened those behavioral contracts.
+
+| Repository | Baseline | First feedback round | Final result | Net change |
+| --- | --- | --- | --- | --- |
+| Backend | 209 killed, 16 survived, 32 no coverage; 81% score / 93% covered strength | 218 / 7 / 32; 85% / 97% | 230 / 0 / 27; 89% / 100% | all 16 covered survivors killed |
+| Frontend | 184 killed + 1 timeout, 85 survived, 37 no coverage; 60.26% / 68.52% | 235 + 1 / 62 / 9; 76.87% / 79.19% | 252 + 1 / 47 / 7; 82.41% / 84.33% | 68 additional mutants detected; 30 fewer uncovered |
+| Ollama mock | 80 killed, 24 survived, 54 no coverage; 51% / 77% | 87 / 18 / 53; 55% / 83% | 137 / 5 / 16; 87% / 96% | 57 additional mutants killed; 38 fewer uncovered |
+| JMS consumer | all seven `JmsConfig` mutants survived | permanent 19-mutant scope: 19 killed, zero survived or uncovered | unchanged: 19 / 0 / 0; 100% / 100% | operational wiring contract added |
+
+The consumer's permanent target is slightly narrower than the exploratory
+wildcard, so its generated-mutant total should not be treated as a direct
+20-to-19 score comparison. The comparable finding is that every original
+`JmsConfig` survivor is now killed.
+
+Concrete improvements:
+
+- refresh-token tests now reject deterministic token generation; removing
+  `SecureRandom.nextBytes` no longer passes;
+- cart tests prove that both quantity-update paths refresh the catalog price
+  and calculate totals from it;
+- product tests prove repository deletion, all updateable fields, and a
+  non-trivial offset/limit slice;
+- frontend tests prove the exact OAuth token-exchange body, PKCE challenge,
+  missing-code/verifier/id-token failures, failed exchange behavior, configured
+  and fallback logout, social-login verifier, loopback gateway, scope, and
+  prompt;
+- the JMS consumer now proves that the listener factory is configured and that
+  `EmailDto` is serialized as a text message with the producer's type-id
+  contract;
+- the Ollama mock now proves that non-streaming generation selects the final
+  response chunk and that tokenization preserves whitespace and final tokens.
+- backend tests now prove password-reset metrics, sanitization and exclusion
+  boundaries, blank product names, and all four Boolean input combinations:
+  Boolean/string crossed with true/false;
+- frontend tests now prove UTF-8 decoding across byte boundaries, multiline and
+  empty SSE events, callback cleanup and retry after a transient exchange
+  failure, entropy fallback, and optional callback behavior;
+- a few mock tests now cover the three public single-response modes and their
+  complete supported-prompt fallbacks. That reachability change alone removed
+  most of the mock's `NO_COVERAGE` results;
+- virtual-time tests prove that ordinary chat/generate chunks use token delay
+  and tool-call chunks use their distinct delay, without sleeping or adding
+  flakiness.
+
+The last backend pair was particularly instructive. A Boolean `false` test and
+a string `"true"` test looked like adequate parser coverage, yet replacement
+mutants survived on Boolean `true` and string `"false"`. Adding the complementary
+representations killed both, taking covered-code strength to 100%.
+
+The frontend also exposed an important stopping rule. Removing `.trim()` from
+two URL inputs still produced the same observable URLs because the `URL`
+constructor normalizes surrounding spaces. A narrow Stryker rerun with coverage
+optimization disabled produced the same survivors. These are equivalent for
+the public result, not an invitation to write implementation-coupled tests.
+Several whole-function/static mutants also ran all tests without affecting
+direct imports; those should be tracked as runner/instrumentation anomalies
+rather than accepted blindly as missing assertions.
+
+These were test-suite defects rather than confirmed production defects. That
+is still an important result: before the follow-up, each listed production
+behavior could be removed or materially changed while the normal suite stayed
+green.
+
+Verification after installation:
+
+- backend: all 429 tests passed; PIT generated 257 mutants, killed all 230
+  covered mutants, and completed in 8 seconds of analysis time;
+- frontend: all 463 tests and ESLint passed; Stryker ran 43 focused tests
+  against 307 mutants in 44 seconds, detecting 253 including one timeout;
+- consumer: 11 tests passed; PIT killed all 19 generated mutants in 2 seconds;
+- mock: all 37 tests passed; PIT generated 158 mutants, killed 137, and
+  completed in 4 seconds. Virtual-time tests added no wall-clock delay.
+
+The operational commands, proposed gates, and agent prompt are documented in
+[`MUTATION_TESTING_AGENT_PLAYBOOK.md`](./MUTATION_TESTING_AGENT_PLAYBOOK.md).
+
+## Executive summary
+
+Mutation testing produced useful, actionable information that the existing
+green test suites and their conventional coverage reports did not expose.
+Across four deliberately scoped samples, the tools generated 742 mutants:
+
+| Repository | Baseline | Scope | Mutants | Killed / timed out | Survived | No coverage | Mutation score | Covered-code test strength |
+| --- | ---: | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Backend | 394/394 tests | 10 high-value classes | 257 | 209 | 16 | 32 | 81% | 93% |
+| Frontend | 443/443 tests | `runtimeConfig.ts`, `sse.ts`, `sso.ts` | 307 | 185 | 85 | 37 | 60.26% | 68.52% |
+| Ollama mock | 23/23 tests | service and token-stream utilities | 158 | 80 | 24 | 54 | 51% | 77% |
+| JMS consumer | 8/8 tests | listener, mail, and JMS configuration | 20 | 12 | 7 | 1 | 60% | 63% |
+| **Observed total** | **868 passing tests** | heterogeneous samples | **742** | **486** | **132** | **124** | **65.5%** | **78.6%** |
+
+The combined total is an observation, not a leaderboard: PIT and Stryker use
+different mutation operators, and each repository sample has a different
+shape. The per-repository survivor lists are more useful than the aggregate.
+
+The clearest coverage comparison came from the frontend. Its full suite reports
+89.25% line coverage, while the three sampled files report 97.14%, 100%, and
+84% line coverage. Their mutation scores were only 76.92%, 61.29%, and 50%,
+respectively. High execution coverage did not imply strong assertions.
+
+## Repositories and reproducibility
+
+The experiment used clean, local clones at these revisions:
+
+| Component | Revision |
+| --- | --- |
+| Backend (`test-secure-backend`) | `aa0b2faae36986fc2015dc0db73e160ad85a3e7b` |
+| Frontend (`vite-react-frontend`) | `4dc12f376b2027b108ab2ce914e82fe954ab91b1` |
+| Consumer (`jms-email-consumer`) | `e44a97287e513da0351ddc55bc660817f5bf5b47` |
+| Model mock (`ollama-mock`) | `a00ad2bb03b53359d66af8f12b293f6fd765f19b` |
+
+Environment:
+
+- Java 25.0.2
+- Maven 3.9.16
+- Node.js 24.15.0
+- Vitest 4.1.10
+- PIT 1.25.8 with `pitest-junit5-plugin` 1.2.3
+- StrykerJS 9.6.1 with the Vitest runner
+
+The baseline reports were first generated from temporary copies at these
+revisions. The implementation follow-up then installed the same scoped PIT and
+Stryker configuration, agent instructions, and mutation-driven tests in the
+working repositories. Production source files remained unchanged.
+
+### Backend sample
+
+The backend sample covered business logic, authentication controls, traffic
+sanitization, and tool-call handlers:
+
+- `ProductService`
+- `CartService`
+- `OrderService`
+- `RefreshTokenService`
+- `PasswordResetService`
+- `AuthRateLimitGuard`
+- `TrafficCapturePolicy`
+- `TrafficDataSanitizer`
+- `ProductCatalogFunctionHandler`
+- `ProductSnapshotFunctionHandler`
+
+PIT initially discovered integration-test classes that are compiled but
+excluded from the normal unit-test phase. Those tests failed in PIT's unit-test
+environment, so the final run explicitly paired the ten production classes
+with their ten green unit-test classes. This is an integration lesson in its
+own right: mutation jobs need the same test selection boundaries as CI.
+
+### Frontend sample
+
+The three files were selected because they contain high-value, independently
+testable behavior:
+
+- runtime URL and SSO configuration;
+- streaming SSE parsing;
+- PKCE/SSO login, callback, and logout behavior.
+
+Stryker ran 23 relevant Vitest tests with per-test coverage analysis. One of the
+307 mutants timed out and is counted as detected by Stryker.
+
+### Convex/Next.js site
+
+The site was inspected as an additional candidate but not assigned a repository
+mutation score. Its baseline had 379 passing tests and one failing content-depth
+release gate while the site was actively changing. Mutation scores are not
+valid when the selected baseline is red, and user-owned work in progress was
+left untouched.
+
+## What the survivors revealed
+
+### Backend: strong suite, specific blind spots
+
+The selected backend tests were the strongest group: 93% test strength for
+covered mutants. The 16 survivors were nevertheless valuable:
+
+- cart tests did not detect removal of price updates in two paths;
+- product tests did not detect a pagination addition changed to subtraction;
+- deletion still passed after the repository `delete` call was removed;
+- three product-update field assignments could be removed without failure;
+- refresh-token tests did not detect removal of `SecureRandom.nextBytes`, a
+  security-critical survivor;
+- password-reset metric callbacks could be removed without failure;
+- traffic exclusion and body/header sanitization boundary changes survived;
+- two tool-call parsing/error predicates could be forced to `true`.
+
+The survivors are not evidence that the implementation is wrong. They show
+that the tests do not currently prove those behaviors. For security-sensitive
+logic such as token entropy, that distinction is important enough to act on.
+
+### Consumer: context tests did not verify wiring
+
+All seven mutants in `JmsConfig` survived. Tests still passed when PIT removed:
+
+- the JMS message converter from the listener factory;
+- the factory configuration call;
+- target message type configuration;
+- type-id property and mappings;
+- both bean return values.
+
+Meanwhile, all five `EmailConsumer` mutants and all seven
+`EmailTemplateRenderer` mutants were killed. The business behavior is asserted;
+the framework wiring is only instantiated. This is a clean example of a green
+Spring context test creating confidence without verifying operational
+configuration.
+
+### Ollama mock: reachability dominates the headline score
+
+The mock's headline mutation score was 51%, but covered-code test strength was
+77%. Fifty-four mutants had no coverage, concentrated in single-response paths,
+scenario aggregation, tool catalog construction, and delay branches.
+
+Important covered survivors included:
+
+- removing reversal of generated chunks;
+- changing tokenization and printable-character boundaries;
+- changing adaptive-delay predicates;
+- weakening supported-prompt formatting.
+
+The right first action is to add tests for the uncovered execution modes, then
+work through the meaningful survivors. Chasing the 51% headline alone would
+mix these two different jobs.
+
+### Frontend: high coverage concealed weak negative-path oracles
+
+The frontend produced the richest survivor list. Examples include:
+
+- an empty OAuth token-exchange request body still passed;
+- missing authorization code, verifier, `id_token`, and failed token response
+  checks could be disabled;
+- SSO login scope and prompt could become empty;
+- the code verifier could become empty on the social-login path;
+- logout behavior had no mutation coverage;
+- the `127.0.0.1` training gateway branch had no coverage;
+- several SSE chunk-boundary and streaming-decoder mutations survived.
+
+Some survivors are low-value or equivalent for the tested inputs, such as
+changes to diagnostic log strings, optional chaining where callbacks are always
+provided, or trimming that is unobservable without whitespace-heavy inputs.
+Stryker's detailed list makes this classification possible; a single score
+does not.
+
+## What prior research says
+
+The proposed use in AI development is not speculative. It is an active research
+direction:
+
+- Just et al. found a statistically significant relationship between mutant
+  detection and real-fault detection independent of code coverage, using 357
+  real faults across five open-source programs.
+  [FSE 2014 paper](https://homes.cs.washington.edu/~mernst/pubs/mutation-effectiveness-fse2014-abstract.html)
+- MuTAP feeds surviving mutants back into LLM prompts. It reported a 93.57%
+  mutation score on synthetic buggy code and detected up to 28% more faulty
+  human-written snippets than its comparison approaches.
+  [MuTAP paper](https://arxiv.org/abs/2308.16557)
+- MUTGEN likewise uses iterative mutation feedback for LLM test generation. It
+  reports cases with 100% coverage but only 4% mutation score and outperforms
+  both EvoSuite and vanilla prompting on 204 subjects.
+  [IEEE TSE publication](https://pure.ul.ie/en/publications/mutation-guided-unit-test-generation-with-a-large-language-model/)
+- SWE-Mutation treats resistance to mutated solutions as a test-suite benchmark.
+  Its 2026 dataset contains 2,636 variants from 800 instances across nine
+  languages, and reports that current LLM-generated suites remain insufficiently
+  discriminative.
+  [ACL 2026 paper](https://aclanthology.org/2026.findings-acl.1976/)
+- Work on LLM-generated mutants finds a complementary trade-off: LLM mutants
+  can be more diverse and behaviorally closer to real bugs, but have worse
+  compilation, duplication, and equivalent-mutant rates than rule-based tools.
+  [TOSEM study](https://discovery.ucl.ac.uk/id/eprint/10223970/)
+- Meta's Automated Compliance Hardening (ACH) narrows mutation to a specific
+  concern, generates a small set of undetected mutants, filters likely
+  equivalents, and then asks an LLM for tests. Across 10,795 Kotlin classes it
+  generated 9,095 mutants and 571 tests; engineers accepted 73% of surfaced
+  tests, with 36% judged privacy-relevant.
+  [ACH paper](https://discovery.ucl.ac.uk/id/eprint/10218052/)
+- An ICST 2025 approach frames the loop as scientific debugging: hypothesize
+  about a surviving mutant, generate a test, observe the result, and refine.
+  It outperformed Pynguin on the studied projects, but also made the compute
+  cost of iterative LLM calls explicit.
+  [Scientific Debugging paper](https://conf.researchr.org/details/icst-2025/mutation-2025-papers/4/Mutation-Testing-via-Iterative-Large-Language-Model-driven-Scientific-Debugging)
+- Meta has also described an ephemeral, change-scoped variant: infer the
+  intended change, generate concern-specific mutants and tests, use multiple
+  assessors, report serious unexpected behavior, then discard the generated
+  tests rather than adding maintenance burden. This is an industry design
+  proposal, not yet a universal replacement for persistent suites.
+  [Meta JiTTesting engineering article](https://engineering.fb.com/2026/02/11/developer-tools/the-death-of-traditional-testing-agentic-development-jit-testing-revival/)
+- Intent-based mutation changes a natural-language behavior or specification
+  and regenerates code implementing the altered intent. Its evaluation found
+  that 55% of generated intent mutants were not subsumed by traditional
+  mutations, supporting it as a complementary layer rather than a replacement.
+  [Intent-Based Mutation Testing](https://conf.researchr.org/details/icst-2025/mutation-2025-papers/5/Intent-Based-Mutation-Testing-From-Naturally-Written-Programming-Intents-to-Mutants)
+- Round-Trip Mutation Testing deliberately introduces code-to-intent-to-code
+  mistranslations. On 40 real buggy methods it produced more syntactically
+  diverse mutants and, under small selected test budgets, reported over 4x and
+  1.7x more detected faults than pattern mutation with 4 and 30 tests.
+  [Round-Trip Mutation Testing](https://conf.researchr.org/details/icst-2026/mutation-2026-papers/7/Round-Trip-Mutation-Testing-Translating-Code-to-Natural-Language-Intent-and-back)
+
+These results support two different uses:
+
+1. conventional deterministic mutants as feedback for an AI test-writing agent;
+2. later, AI-generated semantic mutants as a more realistic holdout evaluation.
+
+The first should come before the second because it is cheaper, reproducible,
+and easier to audit. The strongest architecture is therefore two-layered:
+
+1. **Inner loop:** deterministic PIT/Stryker mutants guide an agent toward
+   stronger persistent tests for stable contracts.
+2. **Outer loop:** sampled, concern-specific LLM mutants challenge the suite
+   with more semantic and realistic faults, either nightly or just in time for
+   a risky change.
+
+The mutation report is best understood as an environment signal or verifier
+for an agent, not as the specification. The agent still needs the requirement,
+public contract, or concern being protected; otherwise it can faithfully encode
+the wrong behavior merely to kill a mutant.
+
+## Codex-generated semantic mutant pilot
+
+The follow-up added an executable semantic-mutant lab under
+[`experiments/llm-mutation`](../experiments/llm-mutation/README.md). Codex
+authored eight frozen, compile-valid patches representing policy, state-order,
+transport, timing, conversation, and compatibility misunderstandings. The
+runner applies each patch only to a temporary copy, validates the green focused
+baseline, compiles the mutant, and classifies the normal suite result.
+
+| Component | Semantic mutants | Initially killed | Initially survived | After focused tests |
+| --- | ---: | ---: | ---: | ---: |
+| Backend | 2 | 0 | 2 | 2 killed |
+| Frontend | 3 | 2 | 1 | 3 killed |
+| Ollama mock | 2 | 2 | 0 | 2 killed |
+| JMS consumer | 1 | 0 | 1 | 1 killed |
+| **Total** | **8** | **4** | **4** | **8 killed** |
+
+The initial survivors were meaningful:
+
+- a partially migrated account was incorrectly treated as SSO-only and denied
+  local password reset;
+- authenticated email/QR traffic was double-counted against user and IP rate
+  limits;
+- training SSO was implicitly enabled on every loopback port rather than only
+  the designated gateway;
+- the legacy fully-qualified JMS producer type identifier was removed while a
+  serialization-only test still passed.
+
+Four contract-level tests killed the frozen survivors. The striking result is
+that the backend had 100% PIT strength for covered mutants before both semantic
+backend mutants survived. The measures are not contradictory: traditional
+operators provide strong local perturbation coverage, while intent mutants can
+change policy across several otherwise valid statements and states.
+
+The pilot also showed transfer. Tests originally added in response to ordinary
+mutants killed four new semantic patches involving retry state, SSE buffering,
+virtual timing, and multi-turn direction. Framework mutation can therefore
+produce tests useful beyond its own operator vocabulary.
+
+This eight-case result must not be presented as a general LLM benchmark. Codex
+had already seen the suites, so generation was white-box and test-aware. A
+controlled follow-up should generate and human-review a blind corpus from
+requirements plus production code, freeze it, and keep a second holdout hidden
+from the test-repair agent. Full results and limitations are in
+[`RESULTS.md`](../experiments/llm-mutation/RESULTS.md).
+
+## Recommended agent workflow
+
+Mutation testing should be a feedback sensor, not an autonomous judge:
+
+1. An implementation agent writes code and tests from the requirement.
+2. Normal checks run first: format, lint, typecheck, unit tests, and coverage.
+3. PIT or Stryker mutates only changed production files or a risk-selected
+   package.
+4. The system separates `NO_COVERAGE` from `SURVIVED`.
+5. A test-focused agent receives one meaningful survivor at a time, plus the
+   requirement and public contract. It should not merely copy the implementation.
+6. The new test must fail against the mutant and pass against the original.
+7. A human or reviewer agent classifies remaining survivors as missing oracle,
+   equivalent/inconsequential, or intentionally untested.
+8. A broader package or repository run happens nightly or weekly.
+
+This loop is useful in an agent-heavy codebase because generation is cheap but
+independent evidence is still scarce. A passing test written by the same model
+from the same implementation context can reproduce the implementation's
+assumptions. A mutant supplies an adversarial, deterministic counterexample.
+
+## Adoption proposal for this stack
+
+Do not begin with a global 80% gate. The current samples show that repository
+shape matters too much.
+
+Start with:
+
+- diff-scoped mutation runs on pull requests, limited to 5-10 minutes;
+- no new meaningful survivors in authentication, token, authorization,
+  sanitization, money, and order-state logic;
+- a ratchet rule: covered-code mutation strength must not fall for changed
+  classes;
+- explicit integration tests for configuration wiring, where unit mutation is
+  otherwise misleading;
+- nightly package-level jobs and a weekly broader trend report;
+- archived JSON/XML reports so an agent can work from exact mutant IDs rather
+  than prose summaries.
+
+Suggested first permanent targets:
+
+| Repository | First target | Reason |
+| --- | --- | --- |
+| Backend | auth/token, cart/order/product, sanitization | high consequence and already fast |
+| Frontend | SSO and SSE libraries | high coverage but many meaningful survivors |
+| Consumer | `JmsConfig` integration contract | all seven wiring mutants survived |
+| Mock | single-response paths and token utilities | large uncovered region plus boundary survivors |
+
+## A controlled follow-up experiment
+
+The present study measures existing suites. It cannot attribute test quality to
+human or agent authorship. To test the AI-specific hypothesis, run a randomized
+evaluation with the same implementation tasks and three conditions:
+
+- **A — coverage feedback:** agent writes tests and sees ordinary coverage;
+- **B — mutation feedback:** same agent and budget, plus one mutation-feedback
+  iteration;
+- **C — independent defender:** a separate test agent receives requirements and
+  survivor diffs, without the implementation agent's hidden reasoning.
+
+Use a frozen holdout set that the agents never see. It should combine:
+
+- conventional unseen mutants;
+- hand-reviewed semantic or higher-order mutants;
+- replayable historical bugs where available.
+
+Measure:
+
+- baseline compile and pass rate;
+- mutation score on the unseen holdout set;
+- historical/seeded real-bug detection;
+- number and readability of added tests;
+- runtime, model tokens, and monetary cost;
+- flake rate across repeated runs;
+- maintenance success after a requirement-preserving refactor.
+
+Without a holdout set, an agent can overfit to the exact mutants it was shown.
+Without real or semantic bugs, the study can optimize for a mutator rather than
+for product risk.
+
+## Post thesis
+
+A strong post can make this argument:
+
+> When agents make code and tests abundant, coverage becomes less scarce and
+> independent evidence becomes more valuable. Mutation testing turns a test
+> suite from a generated artifact into a falsifiable claim: if this small defect
+> were present, would the suite notice?
+
+The stack results keep that thesis grounded: 868 tests were green and reported
+high coverage, yet 132 covered mutants survived. The productive conclusion is
+not that the suites are bad. It is that mutation feedback identifies exactly
+where the next testing effort—and the next agent iteration—has the highest
+information value.
+
+The follow-up makes the claim stronger: without changing production code, the
+agent killed every covered backend mutant, raised the frontend score by 22.15
+points, and raised the mock by 36 points. More importantly, the surviving set
+became qualitatively better: mostly equivalent URL normalization, diagnostic
+branches, static-instrumentation anomalies, and a few empty-section boundaries.
+The useful stopping condition is therefore not 100%; it is the point at which
+all remaining mutants are understood and none represents unproved high-risk
+behavior.

--- a/experiments/llm-mutation/README.md
+++ b/experiments/llm-mutation/README.md
@@ -1,0 +1,78 @@
+# LLM Semantic Mutation Lab
+
+This lab evaluates tests against plausible behavioral defects authored by
+Codex rather than against PIT/Stryker's fixed operators. Every mutant is a
+reviewable patch with an explicit violated contract.
+
+The runner never edits the source repositories. It copies each working tree to
+a temporary directory, applies one patch, compiles it, runs the focused normal
+tests, records `killed` or `survived`, and deletes the temporary copy.
+
+## Run
+
+From `awesome-localstack`:
+
+```bash
+python3 experiments/llm-mutation/run_lab.py \
+  --output experiments/llm-mutation/results/run.json
+```
+
+Run one or more cases by ID:
+
+```bash
+python3 experiments/llm-mutation/run_lab.py \
+  frontend-training-sso-any-loopback-port \
+  consumer-drops-legacy-fqcn-type-id
+```
+
+The default repository locations are sibling checkouts. Change `repository`
+in `manifest.json` when using a different workspace layout. Frontend copies
+reuse the source checkout's `node_modules` through a read-only-style symlink;
+Java copies reuse the local Maven cache.
+
+## Result taxonomy
+
+- `killed`: production compiles and the selected green baseline test fails;
+- `survived`: production compiles and the selected test remains green;
+- `invalid-noncompiling`: the proposed mutant is not admissible;
+- `invalid-patch`: the patch no longer matches the source revision;
+- `baseline-failed`: the result would be uninterpretable, so the mutant is not
+  scored;
+- `test-timeout`: inspect separately; it is evidence of detection only when the
+  timeout is caused by the mutant rather than infrastructure.
+
+Compilation failure is not counted as a kill. A surviving mutant is not
+automatically a test defect: review the stated contract, confirm the behavior
+is observable and supported, and only then add a test.
+
+## Corpus design
+
+The pilot contains eight compile-oriented, semantic changes across backend,
+frontend, model mock, and JMS consumer. They model mistakes an implementation
+agent could plausibly make: over-generalizing a security rule, clearing state
+in the wrong order, confusing transport chunks with protocol events, collapsing
+two timing policies, reading the wrong end of a conversation, and dropping a
+compatibility alias during cleanup.
+
+This first corpus is explicitly **white-box and test-aware**: Codex had already
+worked with these repositories and tests. It is useful as an engineering lab,
+but its score is not an unbiased model benchmark. For a controlled article
+experiment, use a separate generator context that receives requirements and
+production code but not tests or mutation reports. Freeze its compiling,
+human-reviewed patches before exposing them to the test-writing agent.
+
+Suggested blind generator instruction:
+
+> From the requirement and production diff, propose one realistic semantic bug
+> that could be introduced by an AI coding agent. Prefer a multi-line policy,
+> state, ordering, protocol, compatibility, or data-flow mistake over token-level
+> operator replacement. Do not inspect tests. Return a minimal patch, the
+> violated contract, an example observation distinguishing it from the original,
+> and why the change is plausible. The patch must compile.
+
+For a stronger holdout, generate several candidates, reject noncompiling,
+duplicate, equivalent, and requirement-invalid cases, and keep the corpus
+hidden from the agent that writes or repairs tests.
+
+See [`RESULTS.md`](./RESULTS.md) for the first frozen-corpus run and the
+before/after test-strengthening result.

--- a/experiments/llm-mutation/RESULTS.md
+++ b/experiments/llm-mutation/RESULTS.md
@@ -1,0 +1,60 @@
+# Semantic Mutant Pilot Results
+
+Run date: 2026-08-02. Generator: Codex. Corpus: eight frozen,
+compile-valid semantic patches across four repositories.
+
+| Mutant | Initial | After strengthening | Missing proof exposed |
+| --- | --- | --- | --- |
+| backend partial SSO account blocked | survived | killed | incomplete provider metadata must not disable local password reset |
+| backend authenticated route double-counted | survived | killed | user rate limiting and anonymous IP fallback are mutually exclusive |
+| frontend clears PKCE before exchange | killed | killed | callback state survives transient exchange failure |
+| frontend discards previous SSE chunk | killed | killed | protocol events span arbitrary transport chunks |
+| frontend enables training SSO on any loopback port | survived | killed | implicit SSO belongs only to the `:8081` training gateway |
+| mock tool call uses token delay | killed | killed | tool and token latency policies are distinct |
+| mock conversation uses first message | killed | killed | the latest meaningful message advances a tool scenario |
+| consumer drops legacy FQCN type ID | survived | killed | both producer type identifiers remain deserializable |
+
+Initial detection was 4/8 (50%). After four contract-level test additions, the
+same frozen corpus reached 8/8. All eight patches compiled; no compiler rejection
+was counted as a kill. Focused compile-plus-test execution took approximately
+32 seconds for the initial corpus and 31 seconds after strengthening, excluding
+the runner's baseline validation copies.
+
+## What changed in the tests
+
+- `PasswordResetServiceTest` now covers an account with provider metadata but
+  no provider subject. The database permits this partial state, so it is a
+  meaningful migration/resilience contract rather than an artificial input.
+- `AuthRateLimitGuardTest` now proves that authenticated email and QR traffic
+  never resolves or consumes an IP fallback bucket and adds a no-extra-calls
+  oracle.
+- `runtimeConfig.test.ts` now rejects implicit SSO on unrelated localhost and
+  `127.0.0.1` ports.
+- `JmsConfigTest` now deserializes an actual text message carrying the legacy
+  fully-qualified type identifier instead of checking only serialization.
+
+## Interpretation
+
+The backend had already reached 100% PIT test strength for covered mutants, yet
+both Codex-authored backend mutants survived. There is no contradiction: PIT
+measured resistance to its operator set, while these patches changed policy
+across state combinations and control-flow intent. Operator-complete does not
+mean specification-complete.
+
+The four initial kills also matter. Earlier mutation feedback had already added
+the precise retry, byte-boundary, virtual-time, and multi-turn tests that caught
+the semantic variants. Traditional mutation therefore strengthened the suite
+for defects outside the exact framework operator that originally motivated the
+tests.
+
+This is a tiny, test-aware engineering pilot, not a model benchmark. Codex had
+seen the tests before authoring the corpus, and the selected contracts were
+human-reviewed only after execution. A controlled article experiment should
+freeze a blind, independently reviewed corpus before any test agent sees it and
+retain a second hidden holdout to measure overfitting.
+
+Raw execution records:
+
+- [`results/latest.json`](./results/latest.json): initial 4 killed / 4 survived;
+- [`results/after-strengthening.json`](./results/after-strengthening.json):
+  8 killed / 0 survived.

--- a/experiments/llm-mutation/manifest.json
+++ b/experiments/llm-mutation/manifest.json
@@ -1,0 +1,87 @@
+{
+  "schemaVersion": 1,
+  "generatedBy": "Codex",
+  "generationMode": "white-box semantic pilot",
+  "mutants": [
+    {
+      "id": "backend-partial-sso-account-blocked",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-partial-sso-account-blocked.patch",
+      "description": "Treat an account as SSO-only when either provider field is present instead of requiring a complete provider identity.",
+      "contract": "Only users with both authProvider and providerSubject are SSO-only; partially migrated local accounts must retain password reset.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Dtest=PasswordResetServiceTest", "test"]
+    },
+    {
+      "id": "backend-authenticated-route-double-counted",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-authenticated-route-double-counted.patch",
+      "description": "Apply both username and IP limits to authenticated email/QR calls after a defense-in-depth refactor.",
+      "contract": "Authenticated email and QR calls use the user policy; IP is the fallback only when identity is unavailable.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Dtest=AuthRateLimitGuardTest", "test"]
+    },
+    {
+      "id": "frontend-sso-clears-pkce-before-exchange",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-sso-clears-pkce-before-exchange.patch",
+      "description": "Clear one-time PKCE state before the remote token exchange rather than after a successful response.",
+      "contract": "A transient exchange failure must leave callback state available for a safe retry.",
+      "compile": ["npm", "exec", "--", "tsc", "-b", "--pretty", "false"],
+      "test": ["npm", "test", "--", "--run", "src/lib/sso.test.ts"]
+    },
+    {
+      "id": "frontend-sse-discards-previous-network-chunk",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-sse-discards-previous-network-chunk.patch",
+      "description": "Parse only the latest network chunk and overwrite an incomplete buffered SSE event.",
+      "contract": "SSE event boundaries are independent of transport chunk boundaries; incomplete events must be retained.",
+      "compile": ["npm", "exec", "--", "tsc", "-b", "--pretty", "false"],
+      "test": ["npm", "test", "--", "--run", "src/lib/sse.test.ts"]
+    },
+    {
+      "id": "frontend-training-sso-any-loopback-port",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-training-sso-any-loopback-port.patch",
+      "description": "Generalize automatic training SSO activation from the gateway origin to every loopback port.",
+      "contract": "Implicit training SSO is enabled only on the designated localhost:8081 gateway, never on unrelated loopback applications.",
+      "compile": ["npm", "exec", "--", "tsc", "-b", "--pretty", "false"],
+      "test": ["npm", "test", "--", "--run", "src/lib/runtimeConfig.test.ts"]
+    },
+    {
+      "id": "mock-tool-call-uses-token-delay",
+      "component": "mock",
+      "repository": "../ollama-mock",
+      "patch": "mutants/mock-tool-call-uses-token-delay.patch",
+      "description": "Use the ordinary token delay for tool calls, collapsing two latency policies during cleanup.",
+      "contract": "Tool-call chunks use toolCallDelay; textual chunks use tokenDelay; completion is immediate.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Dtest=ChatToolsServiceTest", "test"]
+    },
+    {
+      "id": "mock-conversation-uses-first-message",
+      "component": "mock",
+      "repository": "../ollama-mock",
+      "patch": "mutants/mock-conversation-uses-first-message.patch",
+      "description": "Resolve a multi-turn conversation from the first meaningful message rather than its latest message.",
+      "contract": "Tool scenarios advance according to the latest meaningful user/tool message.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Dtest=ChatToolsServiceTest", "test"]
+    },
+    {
+      "id": "consumer-drops-legacy-fqcn-type-id",
+      "component": "consumer",
+      "repository": "../jms-email-consumer",
+      "patch": "mutants/consumer-drops-legacy-fqcn-type-id.patch",
+      "description": "Keep only the short JMS type identifier and silently remove the legacy producer FQCN alias.",
+      "contract": "The consumer accepts both EmailDTO and com.awesome.testing.dto.email.EmailDTO type identifiers during migration.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Dtest=JmsConfigTest", "test"]
+    }
+  ]
+}

--- a/experiments/llm-mutation/mutants/backend-authenticated-route-double-counted.patch
+++ b/experiments/llm-mutation/mutants/backend-authenticated-route-double-counted.patch
@@ -1,0 +1,11 @@
+diff --git a/src/main/java/com/awesome/testing/security/ratelimit/AuthRateLimitGuard.java b/src/main/java/com/awesome/testing/security/ratelimit/AuthRateLimitGuard.java
+--- a/src/main/java/com/awesome/testing/security/ratelimit/AuthRateLimitGuard.java
++++ b/src/main/java/com/awesome/testing/security/ratelimit/AuthRateLimitGuard.java
+@@ -112,7 +112,6 @@ public class AuthRateLimitGuard {
+         String normalizedUsername = normalize(username);
+         if (normalizedUsername != null) {
+             rateLimitService.check(endpoint, "username", normalizedUsername, authenticatedPolicy);
+-            return;
+         }
+ 
+         String clientIp = clientAddressResolver.resolve(request);

--- a/experiments/llm-mutation/mutants/backend-partial-sso-account-blocked.patch
+++ b/experiments/llm-mutation/mutants/backend-partial-sso-account-blocked.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/java/com/awesome/testing/service/password/PasswordResetService.java b/src/main/java/com/awesome/testing/service/password/PasswordResetService.java
+--- a/src/main/java/com/awesome/testing/service/password/PasswordResetService.java
++++ b/src/main/java/com/awesome/testing/service/password/PasswordResetService.java
+@@ -91,7 +91,7 @@ public class PasswordResetService {
+     }
+ 
+     private boolean isSsoOnlyUser(UserEntity user) {
+-        return StringUtils.hasText(user.getAuthProvider()) && StringUtils.hasText(user.getProviderSubject());
++        return StringUtils.hasText(user.getAuthProvider()) || StringUtils.hasText(user.getProviderSubject());
+     }
+ 
+     private String buildResetLink(String token) {

--- a/experiments/llm-mutation/mutants/consumer-drops-legacy-fqcn-type-id.patch
+++ b/experiments/llm-mutation/mutants/consumer-drops-legacy-fqcn-type-id.patch
@@ -1,0 +1,13 @@
+diff --git a/src/main/java/com/awesome/testing/listener/JmsConfig.java b/src/main/java/com/awesome/testing/listener/JmsConfig.java
+--- a/src/main/java/com/awesome/testing/listener/JmsConfig.java
++++ b/src/main/java/com/awesome/testing/listener/JmsConfig.java
+@@ -34,8 +34,7 @@ public class JmsConfig {
+         converter.setTargetType(MessageType.TEXT);
+         converter.setTypeIdPropertyName("_awesome_");
+         converter.setTypeIdMappings(Map.of(
+-            "EmailDTO", EmailDto.class,
+-            "com.awesome.testing.dto.email.EmailDTO", EmailDto.class
++            "EmailDTO", EmailDto.class
+         ));
+         return converter;
+     }

--- a/experiments/llm-mutation/mutants/frontend-sse-discards-previous-network-chunk.patch
+++ b/experiments/llm-mutation/mutants/frontend-sse-discards-previous-network-chunk.patch
@@ -1,0 +1,14 @@
+diff --git a/src/lib/sse.ts b/src/lib/sse.ts
+--- a/src/lib/sse.ts
++++ b/src/lib/sse.ts
+@@ -24,9 +24,8 @@ export async function processSSEResponse<T>(
+ 
+       if (value) {
+         const chunkText = decoder.decode(value, { stream: true });
+-        buffer += chunkText;
+ 
+-        const events = buffer.split('\n\n');
++        const events = chunkText.split('\n\n');
+         buffer = events.pop() ?? '';
+ 
+         for (const eventBlock of events) {

--- a/experiments/llm-mutation/mutants/frontend-sso-clears-pkce-before-exchange.patch
+++ b/experiments/llm-mutation/mutants/frontend-sso-clears-pkce-before-exchange.patch
@@ -1,0 +1,25 @@
+diff --git a/src/lib/sso.ts b/src/lib/sso.ts
+--- a/src/lib/sso.ts
++++ b/src/lib/sso.ts
+@@ -110,6 +110,10 @@ const completeCallbackOnce = async (
+     throw new Error('Missing SSO code verifier');
+   }
+ 
++  safeRemoveItem(SSO_STATE_KEY);
++  safeRemoveItem(SSO_NONCE_KEY);
++  safeRemoveItem(SSO_CODE_VERIFIER_KEY);
++
+   const tokenResponse = await fetch(`${config.authority}/protocol/openid-connect/token`, {
+     method: 'POST',
+     headers: {
+@@ -136,10 +140,6 @@ const completeCallbackOnce = async (
+     throw new Error('Missing SSO id token');
+   }
+ 
+-  safeRemoveItem(SSO_STATE_KEY);
+-  safeRemoveItem(SSO_NONCE_KEY);
+-  safeRemoveItem(SSO_CODE_VERIFIER_KEY);
+-
+   const response = await idTokenExchange({ idToken: tokenBody.id_token });
+   return response.data;
+ };

--- a/experiments/llm-mutation/mutants/frontend-training-sso-any-loopback-port.patch
+++ b/experiments/llm-mutation/mutants/frontend-training-sso-any-loopback-port.patch
@@ -1,0 +1,13 @@
+diff --git a/src/lib/runtimeConfig.ts b/src/lib/runtimeConfig.ts
+--- a/src/lib/runtimeConfig.ts
++++ b/src/lib/runtimeConfig.ts
+@@ -25,7 +25,8 @@ export type SsoRuntimeConfig = {
+ const getRuntimeOrigin = (location: RuntimeLocation) => trimTrailingSlash(location.origin);
+ const isLocalTrainingGateway = (location: RuntimeLocation) => {
+   const origin = getRuntimeOrigin(location);
+-  return origin === 'http://localhost:8081' || origin === 'http://127.0.0.1:8081';
++  const hostname = new URL(origin).hostname;
++  return hostname === 'localhost' || hostname === '127.0.0.1';
+ };
+ 
+ export const getApiBaseUrl = (

--- a/experiments/llm-mutation/mutants/mock-conversation-uses-first-message.patch
+++ b/experiments/llm-mutation/mutants/mock-conversation-uses-first-message.patch
@@ -1,0 +1,12 @@
+diff --git a/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java b/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java
+--- a/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java
++++ b/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java
+@@ -104,7 +104,7 @@ public class ChatToolsService {
+ 
+     private ChatMessageDto latestMessage(ChatRequestDto request) {
+         List<ChatMessageDto> messages = Optional.ofNullable(request.getMessages()).orElse(List.of());
+-        for (int i = messages.size() - 1; i >= 0; i--) {
++        for (int i = 0; i < messages.size(); i++) {
+             ChatMessageDto message = messages.get(i);
+             if (StringUtils.hasText(message.getRole())) {
+                 return message;

--- a/experiments/llm-mutation/mutants/mock-tool-call-uses-token-delay.patch
+++ b/experiments/llm-mutation/mutants/mock-tool-call-uses-token-delay.patch
@@ -1,0 +1,11 @@
+diff --git a/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java b/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java
+--- a/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java
++++ b/src/main/java/com/awesome/testing/ollama/service/ChatToolsService.java
+@@ -196,6 +196,6 @@ public class ChatToolsService {
+         } else if (chunk.getMessage() != null && chunk.getMessage().getToolCalls() != null
+                 && !chunk.getMessage().getToolCalls().isEmpty()) {
+-            delay = properties.getToolCallDelay();
++            delay = properties.getTokenDelay();
+         } else {
+             delay = properties.getTokenDelay();
+         }

--- a/experiments/llm-mutation/results/after-strengthening.json
+++ b/experiments/llm-mutation/results/after-strengthening.json
@@ -1,0 +1,298 @@
+{
+  "schemaVersion": 1,
+  "manifest": "/Users/slawek/IdeaProjects/awesome-localstack/experiments/llm-mutation/manifest.json",
+  "generationMode": "white-box semantic pilot",
+  "results": [
+    {
+      "id": "backend-partial-sso-account-blocked",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-partial-sso-account-blocked.patch",
+      "description": "Treat an account as SSO-only when either provider field is present instead of requiring a complete provider identity.",
+      "contract": "Only users with both authProvider and providerSubject are SSO-only; partially migrated local accounts must retain password reset.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.029,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 4.258,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.825 s <<< FAILURE! -- in com.awesome.testing.service.password.PasswordResetServiceTest\n[ERROR] com.awesome.testing.service.password.PasswordResetServiceTest.shouldAllowLocalResetWhenSsoIdentityIsIncomplete -- Time elapsed: 0.006 s <<< FAILURE!\norg.opentest4j.AssertionFailedError: \n\nexpected: \"raw-token\"\n but was: null\n\tat com.awesome.testing.service.password.PasswordResetServiceTest.shouldAllowLocalResetWhenSsoIdentityIsIncomplete(PasswordResetServiceTest.java:159)\n\n[ERROR] Failures: \n[ERROR]   PasswordResetServiceTest.shouldAllowLocalResetWhenSsoIdentityIsIncomplete:159 \nexpected: \"raw-token\"\n but was: null\n[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project jwt-auth-service: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-9i4tdjgw/backend-partial-sso-account-blocked/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.028,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 4.297,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "backend-authenticated-route-double-counted",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-authenticated-route-double-counted.patch",
+      "description": "Apply both username and IP limits to authenticated email/QR calls after a defense-in-depth refactor.",
+      "contract": "Authenticated email and QR calls use the user policy; IP is the fallback only when identity is unavailable.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.051,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 3.943,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.488 s <<< FAILURE! -- in com.awesome.testing.security.ratelimit.AuthRateLimitGuardTest\n[ERROR] com.awesome.testing.security.ratelimit.AuthRateLimitGuardTest.shouldRateLimitEmailAndQrByUsernameWhenAuthenticated -- Time elapsed: 0.013 s <<< FAILURE!\norg.mockito.exceptions.verification.NeverWantedButInvoked: \n\nclientAddressResolver.resolve(\n    Mock for HttpServletRequest, hashCode: 1524038030\n);\nNever wanted here:\n-> at com.awesome.testing.security.ratelimit.ClientAddressResolver.resolve(ClientAddressResolver.java:15)\nBut invoked here:\n-> at com.awesome.testing.security.ratelimit.AuthRateLimitGuard.checkAuthenticatedOrIp(AuthRateLimitGuard.java:118) with arguments: [Mock for HttpServletRequest, hashCode: 1524038030]\n-> at com.awesome.testing.security.ratelimit.AuthRateLimitGuard.checkAuthenticatedOrIp(AuthRateLimitGuard.java:118) with arguments: [Mock for HttpServletRequest, hashCode: 1524038030]\n\n\tat com.awesome.testing.security.ratelimit.ClientAddressResolver.resolve(ClientAddressResolver.java:15)\n\tat com.awesome.testing.security.ratelimit.AuthRateLimitGuardTest.shouldRateLimitEmailAndQrByUsernameWhenAuthenticated(AuthRateLimitGuardTest.java:135)\n\n[ERROR] Failures: \n[ERROR]   AuthRateLimitGuardTest.shouldRateLimitEmailAndQrByUsernameWhenAuthenticated:135 \nclientAddressResolver.resolve(\n    Mock for HttpServletRequest, hashCode: 1524038030\n);\nNever wanted here:\n-> at com.awesome.testing.security.ratelimit.ClientAddressResolver.resolve(ClientAddressResolver.java:15)\nBut invoked here:\n-> at com.awesome.testing.security.ratelimit.AuthRateLimitGuard.checkAuthenticatedOrIp(AuthRateLimitGuard.java:118) with arguments: [Mock for HttpServletRequest, hashCode: 1524038030]\n-> at com.awesome.testing.security.ratelimit.AuthRateLimitGuard.checkAuthenticatedOrIp(AuthRateLimitGuard.java:118) with arguments: [Mock for HttpServletRequest, hashCode: 1524038030]\n\n[ERROR] Tests run: 8, Failures: 1, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project jwt-auth-service: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-c7l8lwnw/backend-authenticated-route-double-counted/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.094,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 3.912,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "frontend-sso-clears-pkce-before-exchange",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-sso-clears-pkce-before-exchange.patch",
+      "description": "Clear one-time PKCE state before the remote token exchange rather than after a successful response.",
+      "contract": "A transient exchange failure must leave callback state available for a safe retry.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.795,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.576,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sso.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-cpv3ht45/frontend-sso-clears-pkce-before-exchange\n\n \u276f src/lib/sso.test.ts (18 tests | 1 failed) 9ms\n     \u00d7 retries the same callback after a transient exchange failure 2ms\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af Failed Tests 1 \u23af\u23af\u23af\u23af\u23af\u23af\u23af\n\n FAIL  src/lib/sso.test.ts > sso helper > retries the same callback after a transient exchange failure\nAssertionError: promise rejected \"Error: Missing SSO code verifier\" instead of resolving\n \u276f src/lib/sso.test.ts:313:87\n    311|     await expect(sso.completeCallback(callbackUrl, exchange, ssoEnv, r\u2026\n    312|       .rejects.toThrow('temporary network failure');\n    313|     await expect(sso.completeCallback(callbackUrl, exchange, ssoEnv, r\u2026\n       |                                                                                       ^\n    314|       .resolves.toMatchObject({ token: 'access-retry' });\n    315|     expect(fetchMock).toHaveBeenCalledTimes(2);\n\nCaused by: Error: Missing SSO code verifier\n \u276f completeCallbackOnce src/lib/sso.ts:118:11\n \u276f Object.completeCallback src/lib/sso.ts:265:21\n \u276f src/lib/sso.test.ts:313:22\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  17:38:21\n   Duration  329ms (transform 36ms, setup 40ms, import 32ms, tests 9ms, environment 193ms)\n\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.758,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.573,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sso.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-dxljchvo/frontend-sso-clears-pkce-before-exchange\n\n\n Test Files  1 passed (1)\n      Tests  18 passed (18)\n   Start at  17:38:19\n   Duration  321ms (transform 33ms, setup 43ms, import 29ms, tests 8ms, environment 193ms)\n\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "frontend-sse-discards-previous-network-chunk",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-sse-discards-previous-network-chunk.patch",
+      "description": "Parse only the latest network chunk and overwrite an incomplete buffered SSE event.",
+      "contract": "SSE event boundaries are independent of transport chunk boundaries; incomplete events must be retained.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.798,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.561,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sse.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-q5yjg2jw/frontend-sse-discards-previous-network-chunk\n\nstderr | src/lib/sse.test.ts > processSSEResponse > preserves a UTF-8 character split across network chunks\nSSE parsing error: SyntaxError: Unexpected token '\u017c', \"\u017c\"}\" is not valid JSON\n    at JSON.parse (<anonymous>)\n    at processSSEResponse (/private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-q5yjg2jw/frontend-sse-discards-previous-network-chunk/src/lib/sse.ts:41:31)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-q5yjg2jw/frontend-sse-discards-previous-network-chunk/src/lib/sse.test.ts:71:5\n    at file:///Users/slawek/IdeaProjects/vite-react-frontend/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:20 \u017c\"}\n\n \u276f src/lib/sse.test.ts (11 tests | 1 failed) 7ms\n     \u00d7 preserves a UTF-8 character split across network chunks 2ms\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af Failed Tests 1 \u23af\u23af\u23af\u23af\u23af\u23af\u23af\n\n FAIL  src/lib/sse.test.ts > processSSEResponse > preserves a UTF-8 character split across network chunks\nAssertionError: expected \"vi.fn()\" to be called with arguments: [ { response: '\u017c' } ]\n\nNumber of calls: 0\n\n \u276f src/lib/sse.test.ts:73:33\n     71|     await processSSEResponse(response, processor);\n     72|\n     73|     expect(processor.onMessage).toHaveBeenCalledWith({ response: '\u017c' }\u2026\n       |                                 ^\n     74|     expect(processor.onError).not.toHaveBeenCalled();\n     75|   });\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n\n\n Test Files  1 failed (1)\n      Tests  1 failed | 10 passed (11)\n   Start at  17:38:23\n   Duration  307ms (transform 17ms, setup 43ms, import 10ms, tests 7ms, environment 195ms)\n\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.439,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.56,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sse.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-_vllytaz/frontend-sse-discards-previous-network-chunk\n\n\n Test Files  1 passed (1)\n      Tests  11 passed (11)\n   Start at  17:38:22\n   Duration  304ms (transform 18ms, setup 40ms, import 12ms, tests 7ms, environment 195ms)\n\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "frontend-training-sso-any-loopback-port",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-training-sso-any-loopback-port.patch",
+      "description": "Generalize automatic training SSO activation from the gateway origin to every loopback port.",
+      "contract": "Implicit training SSO is enabled only on the designated localhost:8081 gateway, never on unrelated loopback applications.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.761,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.571,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/runtimeConfig.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-zfcx3v3e/frontend-training-sso-any-loopback-port\n\n \u276f src/lib/runtimeConfig.test.ts (14 tests | 1 failed) 5ms\n     \u00d7 does not implicitly enable training SSO on unrelated loopback ports 2ms\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af Failed Tests 1 \u23af\u23af\u23af\u23af\u23af\u23af\u23af\n\n FAIL  src/lib/runtimeConfig.test.ts > runtimeConfig > does not implicitly enable training SSO on unrelated loopback ports\nAssertionError: expected { enabled: true, \u2026(4) } to be null\n\n- Expected:\nnull\n\n+ Received:\n{\n  \"authority\": \"http://localhost:8082/realms/awesome-testing\",\n  \"clientId\": \"awesome-testing-frontend\",\n  \"enabled\": true,\n  \"postLogoutRedirectUri\": \"http://localhost:5173/login\",\n  \"redirectUri\": \"http://localhost:5173/auth/sso/callback\",\n}\n\n \u276f src/lib/runtimeConfig.test.ts:111:7\n    109|         { origin: 'http://localhost:5173' } as Location,\n    110|       ),\n    111|     ).toBeNull();\n       |       ^\n    112|     expect(\n    113|       getSsoConfig(\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n\n\n Test Files  1 failed (1)\n      Tests  1 failed | 13 passed (14)\n   Start at  17:38:26\n   Duration  315ms (transform 19ms, setup 45ms, import 12ms, tests 5ms, environment 201ms)\n\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.435,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.576,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/runtimeConfig.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-dxvms7r4/frontend-training-sso-any-loopback-port\n\n\n Test Files  1 passed (1)\n      Tests  14 passed (14)\n   Start at  17:38:24\n   Duration  312ms (transform 20ms, setup 44ms, import 14ms, tests 3ms, environment 200ms)\n\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "mock-tool-call-uses-token-delay",
+      "component": "mock",
+      "repository": "../ollama-mock",
+      "patch": "mutants/mock-tool-call-uses-token-delay.patch",
+      "description": "Use the ordinary token delay for tool calls, collapsing two latency policies during cleanup.",
+      "contract": "Tool-call chunks use toolCallDelay; textual chunks use tokenDelay; completion is immediate.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.98,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 2.173,
+        "outputTail": "xConcatMap.java:868)\n\tat reactor.core.publisher.MonoDelayElement$DelayElementSubscriber.run(MonoDelayElement.java:201)\n\tat reactor.test.scheduler.VirtualTimeScheduler.drain(VirtualTimeScheduler.java:405)\n\tat reactor.test.scheduler.VirtualTimeScheduler.advanceTime(VirtualTimeScheduler.java:379)\n\tat reactor.test.scheduler.VirtualTimeScheduler.advanceTimeBy(VirtualTimeScheduler.java:284)\n\tat reactor.test.DefaultStepVerifierBuilder.virtualOrRealWait(DefaultStepVerifierBuilder.java:2448)\n\tat reactor.test.DefaultStepVerifierBuilder$NoEvent.run(DefaultStepVerifierBuilder.java:2465)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.waitTaskEvent(DefaultStepVerifierBuilder.java:1727)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.pollTaskEventOrComplete(DefaultStepVerifierBuilder.java:1748)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.verify(DefaultStepVerifierBuilder.java:1320)\n\t... 4 more\n\tSuppressed: java.lang.AssertionError: expectation failed (expected no event: onNext(ChatResponseDto(model=qwen3.5:2b, createdAt=2026-08-02T15:38:35.005948Z, message=ChatMessageDto(role=assistant, content=null, thinking=null, toolCalls=[ToolCallDto(id=toolcall-adc6a431-22e9-4924-abe3-03a98f1cd55f, function=ToolCallFunctionDto(name=list_products, arguments={category=electronics, inStockOnly=true, limit=25}))], toolName=null), done=false)))\n\t\tat reactor.test.MessageFormatter.assertionError(MessageFormatter.java:115)\n\t\tat reactor.test.MessageFormatter.failPrefix(MessageFormatter.java:104)\n\t\tat reactor.test.MessageFormatter.fail(MessageFormatter.java:73)\n\t\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.setFailure(DefaultStepVerifierBuilder.java:1362)\n\t\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onExpectation(DefaultStepVerifierBuilder.java:1454)\n\t\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onNext(DefaultStepVerifierBuilder.java:1168)\n\t\tat reactor.core.publisher.FluxLimitRequest$FluxLimitRequestSubscriber.onNext(FluxLimitRequest.java:99)\n\t\t... 15 more\n\tSuppressed: java.lang.AssertionError: expectation failed (expected no event: onComplete())\n\t\tat reactor.test.MessageFormatter.assertionError(MessageFormatter.java:115)\n\t\tat reactor.test.MessageFormatter.failPrefix(MessageFormatter.java:104)\n\t\tat reactor.test.MessageFormatter.fail(MessageFormatter.java:73)\n\t\t... 19 more\n\n[ERROR] Failures: \n[ERROR]   ChatToolsServiceTest.shouldUseTheToolCallDelayWithoutWaitingInRealTime:197 Expectation failure(s):\n - reactor.core.Exceptions$CompositeException: Multiple exceptions\n - java.lang.AssertionError: expectation failed (expected no event: onNext(ChatResponseDto(model=qwen3.5:2b, createdAt=2026-08-02T15:38:35.005948Z, message=ChatMessageDto(role=assistant, content=null, thinking=null, toolCalls=[ToolCallDto(id=toolcall-adc6a431-22e9-4924-abe3-03a98f1cd55f, function=ToolCallFunctionDto(name=list_products, arguments={category=electronics, inStockOnly=true, limit=25}))], toolName=null), done=false)))\n - java.lang.AssertionError: expectation failed (expected no event: onComplete())\n[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project ollama-mock: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-gm83rxru/mock-tool-call-uses-token-delay/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 2.004,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 2.167,
+          "outputTail": "testing.ollama.service.ChatToolsService -- [chat-tools][content-token] and\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Samsung\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Galaxy\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] S21.\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Snapshot\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] for\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] iPhone\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 13\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Pro:\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] priced\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] at\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] $999\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] with\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 5\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] unit(s)\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] in\n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:30.842 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] stock.\n17:38:30.845 [main] INFO com.awesome.testing.ollama.scenario.chat.ChatScenarioRepository -- Loaded 7 chat scenario(s) from scenarios/chat-scenarios.json\n17:38:30.846 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][call] prompt='What iphones do we have available? Tell me the details about them' issuing list_products\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "mock-conversation-uses-first-message",
+      "component": "mock",
+      "repository": "../ollama-mock",
+      "patch": "mutants/mock-conversation-uses-first-message.patch",
+      "description": "Resolve a multi-turn conversation from the first meaningful message rather than its latest message.",
+      "contract": "Tool scenarios advance according to the latest meaningful user/tool message.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.982,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 2.163,
+        "outputTail": "der.java:904)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:844)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:836)\n\tat reactor.test.DefaultStepVerifierBuilder.verifyComplete(DefaultStepVerifierBuilder.java:702)\n\tat com.awesome.testing.ollama.service.ChatToolsServiceTest.shouldIssueSnapshotAfterCatalogResult(ChatToolsServiceTest.java:74)\n\n[ERROR] com.awesome.testing.ollama.service.ChatToolsServiceTest.shouldRespondWithSummaryAfterSnapshot -- Time elapsed: 0.003 s <<< FAILURE!\njava.lang.AssertionError: \n\nExpecting actual:\n  \"\"\nto contain:\n  \"iPhone 13 Pro\" \n\tat com.awesome.testing.ollama.service.ChatToolsServiceTest.lambda$shouldRespondWithSummaryAfterSnapshot$0(ChatToolsServiceTest.java:103)\n\tat reactor.test.DefaultStepVerifierBuilder.lambda$consumeNextWith$0(DefaultStepVerifierBuilder.java:282)\n\tat reactor.test.DefaultStepVerifierBuilder$SignalEvent.test(DefaultStepVerifierBuilder.java:2339)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onSignal(DefaultStepVerifierBuilder.java:1554)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onExpectation(DefaultStepVerifierBuilder.java:1501)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onNext(DefaultStepVerifierBuilder.java:1168)\n\tat reactor.core.publisher.Operators$BaseFluxToMonoOperator.completePossiblyEmpty(Operators.java:2093)\n\tat reactor.core.publisher.MonoCollectList$MonoCollectListSubscriber.onComplete(MonoCollectList.java:117)\n\tat reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onComplete(FluxConcatMapNoPrefetch.java:240)\n\tat reactor.core.publisher.FluxConcatArray$ConcatArraySubscriber.onComplete(FluxConcatArray.java:213)\n\tat reactor.core.publisher.FluxConcatArray.subscribe(FluxConcatArray.java:79)\n\tat reactor.core.publisher.Mono.subscribe(Mono.java:4569)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.toVerifierAndSubscribe(DefaultStepVerifierBuilder.java:904)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:844)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:836)\n\tat reactor.test.DefaultStepVerifierBuilder.verifyComplete(DefaultStepVerifierBuilder.java:702)\n\tat com.awesome.testing.ollama.service.ChatToolsServiceTest.shouldRespondWithSummaryAfterSnapshot(ChatToolsServiceTest.java:106)\n\n[ERROR] Failures: \n[ERROR]   ChatToolsServiceTest.shouldIssueSnapshotAfterCatalogResult:74->lambda$shouldIssueSnapshotAfterCatalogResult$0:71 \nexpected: \"get_product_snapshot\"\n but was: \"list_products\"\n[ERROR]   ChatToolsServiceTest.shouldPreferToolCallWhenSingleStageAlsoContainsNarration:218->lambda$shouldPreferToolCallWhenSingleStageAlsoContainsNarration$0:216 \nexpected: \"get_product_snapshot\"\n but was: \"list_products\"\n[ERROR]   ChatToolsServiceTest.shouldRespondWithSummaryAfterSnapshot:106->lambda$shouldRespondWithSummaryAfterSnapshot$0:103 \nExpecting actual:\n  \"\"\nto contain:\n  \"iPhone 13 Pro\" \n[ERROR] Tests run: 9, Failures: 3, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project ollama-mock: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-51llzdls/mock-conversation-uses-first-message/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 1.96,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 2.146,
+          "outputTail": "testing.ollama.service.ChatToolsService -- [chat-tools][content-token] and\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Samsung\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Galaxy\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] S21.\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Snapshot\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] for\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] iPhone\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 13\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Pro:\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] priced\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] at\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] $999\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] with\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 5\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] unit(s)\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] in\n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:38:39.148 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] stock.\n17:38:39.151 [main] INFO com.awesome.testing.ollama.scenario.chat.ChatScenarioRepository -- Loaded 7 chat scenario(s) from scenarios/chat-scenarios.json\n17:38:39.151 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][call] prompt='What iphones do we have available? Tell me the details about them' issuing list_products\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "consumer-drops-legacy-fqcn-type-id",
+      "component": "consumer",
+      "repository": "../jms-email-consumer",
+      "patch": "mutants/consumer-drops-legacy-fqcn-type-id.patch",
+      "description": "Keep only the short JMS type identifier and silently remove the legacy producer FQCN alias.",
+      "contract": "The consumer accepts both EmailDTO and com.awesome.testing.dto.email.EmailDTO type identifiers during migration.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.63,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 2.36,
+        "outputTail": "n.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nMockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nWARNING: A Java agent has been loaded dynamically (/Users/slawek/.m2/repository/net/bytebuddy/byte-buddy-agent/1.18.10/byte-buddy-agent-1.18.10.jar)\nWARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning\nWARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information\nWARNING: Dynamic loading of agents will be disallowed by default in a future release\n[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.532 s <<< FAILURE! -- in com.awesome.testing.listener.JmsConfigTest\n[ERROR] com.awesome.testing.listener.JmsConfigTest.shouldDeserializeTheLegacyProducerTypeIdentifier -- Time elapsed: 0.005 s <<< ERROR!\norg.springframework.jms.support.converter.MessageConversionException: Failed to resolve type id [com.awesome.testing.dto.email.EmailDTO]\n\tat org.springframework.jms.support.converter.JacksonJsonMessageConverter.getJavaTypeForMessage(JacksonJsonMessageConverter.java:493)\n\tat org.springframework.jms.support.converter.JacksonJsonMessageConverter.fromMessage(JacksonJsonMessageConverter.java:261)\n\tat com.awesome.testing.listener.JmsConfigTest.shouldDeserializeTheLegacyProducerTypeIdentifier(JmsConfigTest.java:72)\nCaused by: java.lang.NoClassDefFoundError: com/awesome/testing/dto/email/EmailDTO (wrong name: com/awesome/testing/dto/email/EmailDto)\n\tat java.base/java.lang.ClassLoader.defineClass1(Native Method)\n\tat java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962)\n\tat java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144)\n\tat java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:776)\n\tat java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:691)\n\tat java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:620)\n\tat java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:578)\n\tat java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)\n\tat java.base/java.lang.Class.forName0(Native Method)\n\tat java.base/java.lang.Class.forName(Class.java:547)\n\tat org.springframework.util.ClassUtils.forName(ClassUtils.java:308)\n\tat org.springframework.jms.support.converter.JacksonJsonMessageConverter.getJavaTypeForMessage(JacksonJsonMessageConverter.java:489)\n\t... 2 more\n\n[ERROR] Errors: \n[ERROR]   JmsConfigTest.shouldDeserializeTheLegacyProducerTypeIdentifier:72 \u00bb MessageConversion Failed to resolve type id [com.awesome.testing.dto.email.EmailDTO]\n[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project consumer: \n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-y6gh80n4/consumer-drops-legacy-fqcn-type-id/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 1.638,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 2.35,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nMockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nWARNING: A Java agent has been loaded dynamically (/Users/slawek/.m2/repository/net/bytebuddy/byte-buddy-agent/1.18.10/byte-buddy-agent-1.18.10.jar)\nWARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning\nWARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information\nWARNING: Dynamic loading of agents will be disallowed by default in a future release\n",
+          "timedOut": false
+        }
+      }
+    }
+  ],
+  "summary": {
+    "killed": 8
+  }
+}

--- a/experiments/llm-mutation/results/latest.json
+++ b/experiments/llm-mutation/results/latest.json
@@ -1,0 +1,299 @@
+{
+  "schemaVersion": 1,
+  "manifest": "/Users/slawek/IdeaProjects/awesome-localstack/experiments/llm-mutation/manifest.json",
+  "generationMode": "white-box semantic pilot",
+  "results": [
+    {
+      "id": "backend-partial-sso-account-blocked",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-partial-sso-account-blocked.patch",
+      "description": "Treat an account as SSO-only when either provider field is present instead of requiring a complete provider identity.",
+      "contract": "Only users with both authProvider and providerSubject are SSO-only; partially migrated local accounts must retain password reset.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.006,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 0,
+        "durationSeconds": 4.207,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+        "timedOut": false
+      },
+      "status": "survived",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.274,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 4.289,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "backend-authenticated-route-double-counted",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-authenticated-route-double-counted.patch",
+      "description": "Apply both username and IP limits to authenticated email/QR calls after a defense-in-depth refactor.",
+      "contract": "Authenticated email and QR calls use the user policy; IP is the fallback only when identity is unavailable.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.013,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 0,
+        "durationSeconds": 3.865,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+        "timedOut": false
+      },
+      "status": "survived",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.075,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 3.902,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "frontend-sso-clears-pkce-before-exchange",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-sso-clears-pkce-before-exchange.patch",
+      "description": "Clear one-time PKCE state before the remote token exchange rather than after a successful response.",
+      "contract": "A transient exchange failure must leave callback state available for a safe retry.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.831,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.574,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sso.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-45_2fmb1/frontend-sso-clears-pkce-before-exchange\n\n \u276f src/lib/sso.test.ts (18 tests | 1 failed) 9ms\n     \u00d7 retries the same callback after a transient exchange failure 2ms\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af Failed Tests 1 \u23af\u23af\u23af\u23af\u23af\u23af\u23af\n\n FAIL  src/lib/sso.test.ts > sso helper > retries the same callback after a transient exchange failure\nAssertionError: promise rejected \"Error: Missing SSO code verifier\" instead of resolving\n \u276f src/lib/sso.test.ts:313:87\n    311|     await expect(sso.completeCallback(callbackUrl, exchange, ssoEnv, r\u2026\n    312|       .rejects.toThrow('temporary network failure');\n    313|     await expect(sso.completeCallback(callbackUrl, exchange, ssoEnv, r\u2026\n       |                                                                                       ^\n    314|       .resolves.toMatchObject({ token: 'access-retry' });\n    315|     expect(fetchMock).toHaveBeenCalledTimes(2);\n\nCaused by: Error: Missing SSO code verifier\n \u276f completeCallbackOnce src/lib/sso.ts:118:11\n \u276f Object.completeCallback src/lib/sso.ts:265:21\n \u276f src/lib/sso.test.ts:313:22\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n\n\n Test Files  1 failed (1)\n      Tests  1 failed | 17 passed (18)\n   Start at  17:35:23\n   Duration  324ms (transform 32ms, setup 43ms, import 28ms, tests 9ms, environment 193ms)\n\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.465,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.6,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sso.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-lalniupx/frontend-sso-clears-pkce-before-exchange\n\n\n Test Files  1 passed (1)\n      Tests  18 passed (18)\n   Start at  17:35:20\n   Duration  343ms (transform 34ms, setup 47ms, import 30ms, tests 8ms, environment 209ms)\n\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "frontend-sse-discards-previous-network-chunk",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-sse-discards-previous-network-chunk.patch",
+      "description": "Parse only the latest network chunk and overwrite an incomplete buffered SSE event.",
+      "contract": "SSE event boundaries are independent of transport chunk boundaries; incomplete events must be retained.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.794,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.555,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sse.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-hie2zrnk/frontend-sse-discards-previous-network-chunk\n\nstderr | src/lib/sse.test.ts > processSSEResponse > preserves a UTF-8 character split across network chunks\nSSE parsing error: SyntaxError: Unexpected token '\u017c', \"\u017c\"}\" is not valid JSON\n    at JSON.parse (<anonymous>)\n    at processSSEResponse (/private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-hie2zrnk/frontend-sse-discards-previous-network-chunk/src/lib/sse.ts:41:31)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-hie2zrnk/frontend-sse-discards-previous-network-chunk/src/lib/sse.test.ts:71:5\n    at file:///Users/slawek/IdeaProjects/vite-react-frontend/node_modules/@vitest/runner/dist/chunk-artifact.js:1903:20 \u017c\"}\n\n \u276f src/lib/sse.test.ts (11 tests | 1 failed) 8ms\n     \u00d7 preserves a UTF-8 character split across network chunks 2ms\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af Failed Tests 1 \u23af\u23af\u23af\u23af\u23af\u23af\u23af\n\n FAIL  src/lib/sse.test.ts > processSSEResponse > preserves a UTF-8 character split across network chunks\nAssertionError: expected \"vi.fn()\" to be called with arguments: [ { response: '\u017c' } ]\n\nNumber of calls: 0\n\n \u276f src/lib/sse.test.ts:73:33\n     71|     await processSSEResponse(response, processor);\n     72|\n     73|     expect(processor.onMessage).toHaveBeenCalledWith({ response: '\u017c' }\u2026\n       |                                 ^\n     74|     expect(processor.onError).not.toHaveBeenCalled();\n     75|   });\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n\n\n Test Files  1 failed (1)\n      Tests  1 failed | 10 passed (11)\n   Start at  17:35:25\n   Duration  303ms (transform 16ms, setup 43ms, import 9ms, tests 8ms, environment 194ms)\n\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.434,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.563,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/sse.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-is1yljvo/frontend-sse-discards-previous-network-chunk\n\n\n Test Files  1 passed (1)\n      Tests  11 passed (11)\n   Start at  17:35:24\n   Duration  305ms (transform 18ms, setup 43ms, import 12ms, tests 7ms, environment 192ms)\n\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "frontend-training-sso-any-loopback-port",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-training-sso-any-loopback-port.patch",
+      "description": "Generalize automatic training SSO activation from the gateway origin to every loopback port.",
+      "contract": "Implicit training SSO is enabled only on the designated localhost:8081 gateway, never on unrelated loopback applications.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.759,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 0,
+        "durationSeconds": 0.559,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/runtimeConfig.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-pv539zit/frontend-training-sso-any-loopback-port\n\n\n Test Files  1 passed (1)\n      Tests  13 passed (13)\n   Start at  17:35:28\n   Duration  300ms (transform 20ms, setup 43ms, import 13ms, tests 3ms, environment 192ms)\n\n",
+        "timedOut": false
+      },
+      "status": "survived",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.432,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.553,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/lib/runtimeConfig.test.ts\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-srxkifts/frontend-training-sso-any-loopback-port\n\n\n Test Files  1 passed (1)\n      Tests  13 passed (13)\n   Start at  17:35:26\n   Duration  298ms (transform 18ms, setup 43ms, import 11ms, tests 3ms, environment 192ms)\n\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "mock-tool-call-uses-token-delay",
+      "component": "mock",
+      "repository": "../ollama-mock",
+      "patch": "mutants/mock-tool-call-uses-token-delay.patch",
+      "description": "Use the ordinary token delay for tool calls, collapsing two latency policies during cleanup.",
+      "contract": "Tool-call chunks use toolCallDelay; textual chunks use tokenDelay; completion is immediate.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.966,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 2.204,
+        "outputTail": "xConcatMap.java:868)\n\tat reactor.core.publisher.MonoDelayElement$DelayElementSubscriber.run(MonoDelayElement.java:201)\n\tat reactor.test.scheduler.VirtualTimeScheduler.drain(VirtualTimeScheduler.java:405)\n\tat reactor.test.scheduler.VirtualTimeScheduler.advanceTime(VirtualTimeScheduler.java:379)\n\tat reactor.test.scheduler.VirtualTimeScheduler.advanceTimeBy(VirtualTimeScheduler.java:284)\n\tat reactor.test.DefaultStepVerifierBuilder.virtualOrRealWait(DefaultStepVerifierBuilder.java:2448)\n\tat reactor.test.DefaultStepVerifierBuilder$NoEvent.run(DefaultStepVerifierBuilder.java:2465)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.waitTaskEvent(DefaultStepVerifierBuilder.java:1727)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.pollTaskEventOrComplete(DefaultStepVerifierBuilder.java:1748)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.verify(DefaultStepVerifierBuilder.java:1320)\n\t... 4 more\n\tSuppressed: java.lang.AssertionError: expectation failed (expected no event: onNext(ChatResponseDto(model=qwen3.5:2b, createdAt=2026-08-02T15:35:36.871103Z, message=ChatMessageDto(role=assistant, content=null, thinking=null, toolCalls=[ToolCallDto(id=toolcall-74175229-9688-4bc7-8cdc-382a70dbe808, function=ToolCallFunctionDto(name=list_products, arguments={category=electronics, inStockOnly=true, limit=25}))], toolName=null), done=false)))\n\t\tat reactor.test.MessageFormatter.assertionError(MessageFormatter.java:115)\n\t\tat reactor.test.MessageFormatter.failPrefix(MessageFormatter.java:104)\n\t\tat reactor.test.MessageFormatter.fail(MessageFormatter.java:73)\n\t\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.setFailure(DefaultStepVerifierBuilder.java:1362)\n\t\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onExpectation(DefaultStepVerifierBuilder.java:1454)\n\t\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onNext(DefaultStepVerifierBuilder.java:1168)\n\t\tat reactor.core.publisher.FluxLimitRequest$FluxLimitRequestSubscriber.onNext(FluxLimitRequest.java:99)\n\t\t... 15 more\n\tSuppressed: java.lang.AssertionError: expectation failed (expected no event: onComplete())\n\t\tat reactor.test.MessageFormatter.assertionError(MessageFormatter.java:115)\n\t\tat reactor.test.MessageFormatter.failPrefix(MessageFormatter.java:104)\n\t\tat reactor.test.MessageFormatter.fail(MessageFormatter.java:73)\n\t\t... 19 more\n\n[ERROR] Failures: \n[ERROR]   ChatToolsServiceTest.shouldUseTheToolCallDelayWithoutWaitingInRealTime:197 Expectation failure(s):\n - reactor.core.Exceptions$CompositeException: Multiple exceptions\n - java.lang.AssertionError: expectation failed (expected no event: onNext(ChatResponseDto(model=qwen3.5:2b, createdAt=2026-08-02T15:35:36.871103Z, message=ChatMessageDto(role=assistant, content=null, thinking=null, toolCalls=[ToolCallDto(id=toolcall-74175229-9688-4bc7-8cdc-382a70dbe808, function=ToolCallFunctionDto(name=list_products, arguments={category=electronics, inStockOnly=true, limit=25}))], toolName=null), done=false)))\n - java.lang.AssertionError: expectation failed (expected no event: onComplete())\n[ERROR] Tests run: 9, Failures: 1, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project ollama-mock: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-syapcrb7/mock-tool-call-uses-token-delay/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 1.983,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 2.143,
+          "outputTail": "testing.ollama.service.ChatToolsService -- [chat-tools][content-token] and\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Samsung\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Galaxy\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] S21.\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Snapshot\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] for\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] iPhone\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 13\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Pro:\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] priced\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] at\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] $999\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] with\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 5\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] unit(s)\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] in\n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:32.699 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] stock.\n17:35:32.702 [main] INFO com.awesome.testing.ollama.scenario.chat.ChatScenarioRepository -- Loaded 7 chat scenario(s) from scenarios/chat-scenarios.json\n17:35:32.702 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][call] prompt='What iphones do we have available? Tell me the details about them' issuing list_products\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "mock-conversation-uses-first-message",
+      "component": "mock",
+      "repository": "../ollama-mock",
+      "patch": "mutants/mock-conversation-uses-first-message.patch",
+      "description": "Resolve a multi-turn conversation from the first meaningful message rather than its latest message.",
+      "contract": "Tool scenarios advance according to the latest meaningful user/tool message.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.958,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 2.163,
+        "outputTail": "der.java:904)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:844)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:836)\n\tat reactor.test.DefaultStepVerifierBuilder.verifyComplete(DefaultStepVerifierBuilder.java:702)\n\tat com.awesome.testing.ollama.service.ChatToolsServiceTest.shouldIssueSnapshotAfterCatalogResult(ChatToolsServiceTest.java:74)\n\n[ERROR] com.awesome.testing.ollama.service.ChatToolsServiceTest.shouldRespondWithSummaryAfterSnapshot -- Time elapsed: 0.004 s <<< FAILURE!\njava.lang.AssertionError: \n\nExpecting actual:\n  \"\"\nto contain:\n  \"iPhone 13 Pro\" \n\tat com.awesome.testing.ollama.service.ChatToolsServiceTest.lambda$shouldRespondWithSummaryAfterSnapshot$0(ChatToolsServiceTest.java:103)\n\tat reactor.test.DefaultStepVerifierBuilder.lambda$consumeNextWith$0(DefaultStepVerifierBuilder.java:282)\n\tat reactor.test.DefaultStepVerifierBuilder$SignalEvent.test(DefaultStepVerifierBuilder.java:2339)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onSignal(DefaultStepVerifierBuilder.java:1554)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onExpectation(DefaultStepVerifierBuilder.java:1501)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultVerifySubscriber.onNext(DefaultStepVerifierBuilder.java:1168)\n\tat reactor.core.publisher.Operators$BaseFluxToMonoOperator.completePossiblyEmpty(Operators.java:2093)\n\tat reactor.core.publisher.MonoCollectList$MonoCollectListSubscriber.onComplete(MonoCollectList.java:117)\n\tat reactor.core.publisher.FluxConcatMapNoPrefetch$FluxConcatMapNoPrefetchSubscriber.onComplete(FluxConcatMapNoPrefetch.java:240)\n\tat reactor.core.publisher.FluxConcatArray$ConcatArraySubscriber.onComplete(FluxConcatArray.java:213)\n\tat reactor.core.publisher.FluxConcatArray.subscribe(FluxConcatArray.java:79)\n\tat reactor.core.publisher.Mono.subscribe(Mono.java:4569)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.toVerifierAndSubscribe(DefaultStepVerifierBuilder.java:904)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:844)\n\tat reactor.test.DefaultStepVerifierBuilder$DefaultStepVerifier.verify(DefaultStepVerifierBuilder.java:836)\n\tat reactor.test.DefaultStepVerifierBuilder.verifyComplete(DefaultStepVerifierBuilder.java:702)\n\tat com.awesome.testing.ollama.service.ChatToolsServiceTest.shouldRespondWithSummaryAfterSnapshot(ChatToolsServiceTest.java:106)\n\n[ERROR] Failures: \n[ERROR]   ChatToolsServiceTest.shouldIssueSnapshotAfterCatalogResult:74->lambda$shouldIssueSnapshotAfterCatalogResult$0:71 \nexpected: \"get_product_snapshot\"\n but was: \"list_products\"\n[ERROR]   ChatToolsServiceTest.shouldPreferToolCallWhenSingleStageAlsoContainsNarration:218->lambda$shouldPreferToolCallWhenSingleStageAlsoContainsNarration$0:216 \nexpected: \"get_product_snapshot\"\n but was: \"list_products\"\n[ERROR]   ChatToolsServiceTest.shouldRespondWithSummaryAfterSnapshot:106->lambda$shouldRespondWithSummaryAfterSnapshot$0:103 \nExpecting actual:\n  \"\"\nto contain:\n  \"iPhone 13 Pro\" \n[ERROR] Tests run: 9, Failures: 3, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project ollama-mock: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-gukcp2iw/mock-conversation-uses-first-message/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 2.009,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 2.177,
+          "outputTail": "testing.ollama.service.ChatToolsService -- [chat-tools][content-token] and\n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Samsung\n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Galaxy\n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] S21.\n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Snapshot\n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] for\n17:35:41.099 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] iPhone\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 13\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] Pro:\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] priced\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] at\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] $999\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] with\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] 5\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] unit(s)\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] in\n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token]  \n17:35:41.100 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][content-token] stock.\n17:35:41.103 [main] INFO com.awesome.testing.ollama.scenario.chat.ChatScenarioRepository -- Loaded 7 chat scenario(s) from scenarios/chat-scenarios.json\n17:35:41.103 [main] INFO com.awesome.testing.ollama.service.ChatToolsService -- [chat-tools][call] prompt='What iphones do we have available? Tell me the details about them' issuing list_products\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "consumer-drops-legacy-fqcn-type-id",
+      "component": "consumer",
+      "repository": "../jms-email-consumer",
+      "patch": "mutants/consumer-drops-legacy-fqcn-type-id.patch",
+      "description": "Keep only the short JMS type identifier and silently remove the legacy producer FQCN alias.",
+      "contract": "The consumer accepts both EmailDTO and com.awesome.testing.dto.email.EmailDTO type identifiers during migration.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 1.694,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 0,
+        "durationSeconds": 2.357,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nMockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nWARNING: A Java agent has been loaded dynamically (/Users/slawek/.m2/repository/net/bytebuddy/byte-buddy-agent/1.18.10/byte-buddy-agent-1.18.10.jar)\nWARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning\nWARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information\nWARNING: Dynamic loading of agents will be disallowed by default in a future release\n",
+        "timedOut": false
+      },
+      "status": "survived",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 1.639,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 2.335,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nMockito is currently self-attaching to enable the inline-mock-maker. This will no longer work in future releases of the JDK. Please add Mockito as an agent to your build as described in Mockito's documentation: https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#0.3\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nWARNING: A Java agent has been loaded dynamically (/Users/slawek/.m2/repository/net/bytebuddy/byte-buddy-agent/1.18.10/byte-buddy-agent-1.18.10.jar)\nWARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning\nWARNING: If a serviceability tool is not in use, please run with -Djdk.instrument.traceUsage for more information\nWARNING: Dynamic loading of agents will be disallowed by default in a future release\n",
+          "timedOut": false
+        }
+      }
+    }
+  ],
+  "summary": {
+    "killed": 4,
+    "survived": 4
+  }
+}

--- a/experiments/llm-mutation/run_lab.py
+++ b/experiments/llm-mutation/run_lab.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Run Codex-authored semantic mutants in disposable repository copies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+
+LAB_DIR = Path(__file__).resolve().parent
+STACK_ROOT = LAB_DIR.parents[1]
+DEFAULT_MANIFEST = LAB_DIR / "manifest.json"
+IGNORED_NAMES = {
+    ".git",
+    ".idea",
+    ".next",
+    "coverage",
+    "dist",
+    "node_modules",
+    "reports",
+    "target",
+    "test-results",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compile and test LLM-generated mutants outside the working repositories."
+    )
+    parser.add_argument("ids", nargs="*", help="Mutant IDs; defaults to the full manifest")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--output", type=Path, help="Write JSON results to this path")
+    parser.add_argument("--skip-baseline", action="store_true")
+    parser.add_argument("--timeout", type=int, default=180, help="Seconds per command")
+    return parser.parse_args()
+
+
+def copy_repository(source: Path, destination: Path) -> None:
+    shutil.copytree(
+        source,
+        destination,
+        ignore=shutil.ignore_patterns(*IGNORED_NAMES),
+        symlinks=True,
+    )
+    source_modules = source / "node_modules"
+    if source_modules.is_dir():
+        (destination / "node_modules").symlink_to(source_modules, target_is_directory=True)
+
+
+def run_command(command: list[str], cwd: Path, timeout: int) -> dict[str, Any]:
+    started = time.monotonic()
+    try:
+        process = subprocess.run(
+            command,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            env={**os.environ, "CI": "true"},
+            check=False,
+        )
+        return {
+            "exitCode": process.returncode,
+            "durationSeconds": round(time.monotonic() - started, 3),
+            "outputTail": process.stdout[-4000:],
+            "timedOut": False,
+        }
+    except subprocess.TimeoutExpired as error:
+        output = error.stdout or ""
+        if isinstance(output, bytes):
+            output = output.decode(errors="replace")
+        return {
+            "exitCode": None,
+            "durationSeconds": round(time.monotonic() - started, 3),
+            "outputTail": output[-4000:],
+            "timedOut": True,
+        }
+
+
+def prepare_copy(source: Path, temporary_root: Path, label: str) -> Path:
+    destination = temporary_root / label
+    copy_repository(source, destination)
+    return destination
+
+
+def execute_baseline(mutant: dict[str, Any], source: Path, timeout: int) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="llm-mutant-baseline-") as raw_root:
+        checkout = prepare_copy(source, Path(raw_root), mutant["id"])
+        compile_result = run_command(mutant["compile"], checkout, timeout)
+        if compile_result["exitCode"] != 0:
+            return {"status": "compile-failed", "compile": compile_result}
+        test_result = run_command(mutant["test"], checkout, timeout)
+        status = "passed" if test_result["exitCode"] == 0 else "test-failed"
+        return {"status": status, "compile": compile_result, "test": test_result}
+
+
+def execute_mutant(mutant: dict[str, Any], source: Path, patch: Path, timeout: int) -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="llm-mutant-") as raw_root:
+        checkout = prepare_copy(source, Path(raw_root), mutant["id"])
+        apply_result = run_command(["git", "apply", str(patch)], checkout, timeout)
+        if apply_result["exitCode"] != 0:
+            return {"status": "invalid-patch", "apply": apply_result}
+
+        compile_result = run_command(mutant["compile"], checkout, timeout)
+        if compile_result["timedOut"]:
+            return {"status": "compile-timeout", "compile": compile_result}
+        if compile_result["exitCode"] != 0:
+            return {"status": "invalid-noncompiling", "compile": compile_result}
+
+        test_result = run_command(mutant["test"], checkout, timeout)
+        if test_result["timedOut"]:
+            status = "test-timeout"
+        elif test_result["exitCode"] == 0:
+            status = "survived"
+        else:
+            status = "killed"
+        return {"status": status, "compile": compile_result, "test": test_result}
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = args.manifest.resolve()
+    manifest = json.loads(manifest_path.read_text())
+    requested = set(args.ids)
+    mutants = [
+        item for item in manifest["mutants"] if not requested or item["id"] in requested
+    ]
+    missing = requested - {item["id"] for item in mutants}
+    if missing:
+        raise SystemExit(f"Unknown mutant IDs: {', '.join(sorted(missing))}")
+
+    results: list[dict[str, Any]] = []
+    for index, mutant in enumerate(mutants, start=1):
+        source = (STACK_ROOT / mutant["repository"]).resolve()
+        patch = (LAB_DIR / mutant["patch"]).resolve()
+        if not source.is_dir():
+            raise SystemExit(f"Repository does not exist: {source}")
+        if not patch.is_file():
+            raise SystemExit(f"Patch does not exist: {patch}")
+
+        print(f"[{index}/{len(mutants)}] {mutant['id']}", flush=True)
+        baseline = None
+        if not args.skip_baseline:
+            baseline = execute_baseline(mutant, source, args.timeout)
+            if baseline["status"] != "passed":
+                result = {**mutant, "status": "baseline-failed", "baseline": baseline}
+                results.append(result)
+                print(f"  -> {result['status']}", flush=True)
+                continue
+
+        execution = execute_mutant(mutant, source, patch, args.timeout)
+        result = {**mutant, **execution}
+        if baseline is not None:
+            result["baseline"] = baseline
+        results.append(result)
+        print(f"  -> {result['status']}", flush=True)
+
+    report = {
+        "schemaVersion": 1,
+        "manifest": str(manifest_path),
+        "generationMode": manifest.get("generationMode"),
+        "results": results,
+        "summary": {
+            status: sum(item["status"] == status for item in results)
+            for status in sorted({item["status"] for item in results})
+        },
+    }
+    rendered = json.dumps(report, indent=2) + "\n"
+    if args.output:
+        output = args.output.resolve()
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(rendered)
+        print(f"Results written to {output}")
+    else:
+        print(rendered)
+
+    unexpected = {"baseline-failed", "compile-timeout", "invalid-noncompiling", "invalid-patch"}
+    return 2 if any(item["status"] in unexpected for item in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.14@sha256:dd310697d66c389eab971adb8cbb07cf00fc17d824f4775b99e8dbdce7271ad7
+    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
     restart: always
     expose:
       - "4001"
@@ -38,7 +38,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.12@sha256:59acd367dca78a0aea8776467885eda39d56b8259906a0f110d7063e6ff7e112
+    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
     restart: always
     expose:
       - "80"
@@ -94,7 +94,7 @@ services:
       - my-private-ntwk
 
   ollama-mock:
-    image: slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e
+    image: slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab
     restart: always
     ports:
       - "11434:11434"

--- a/scripts/verify-ollama-config.sh
+++ b/scripts/verify-ollama-config.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 DEFAULT_MODEL="hf.co/prism-ml/Bonsai-27B-gguf:Q1_0"
 QWEN_MODEL="hf.co/unsloth/Qwen3.5-2B-GGUF:Q4_K_M"
-MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.8@sha256:9859266fbd274ae3030d3b191fe795de76710c0019ee4c33913658cffc7e712e"
+MOCK_IMAGE="slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab"
 
 default_config="$(OLLAMA_BASE_URL=http://ollama:11434 docker compose -f docker-compose.yml config)"
 grep -F "name: awesome-full-native" <<<"$default_config"


### PR DESCRIPTION
## What changed
- add the empirical mutation-testing study and agent operating playbook
- add a frozen eight-case LLM semantic-mutant lab with before/after results
- link the mutation material from the main README
- update all Compose profiles to backend 3.7.15, frontend 3.7.13, consumer 3.3.7, and Ollama mock 1.0.9 using immutable Docker Hub manifest digests
- synchronize the compatibility-set documentation

## Why
Make mutation testing an executable feedback tool for coding agents, preserve concrete evidence from this stack, and deploy a single unambiguous compatibility set containing the merged test/harness changes.

## Validation
- every modified Compose profile: `docker compose config --quiet`
- `python3 scripts/verify-image-pins.py`
- `python3 scripts/verify-release-images.py`
- Docker Hub metadata confirms amd64 and arm64 for all four exact manifests
- frozen semantic lab rerun: 8/8 mutants killed
- component release and follow-up CI workflows passed