### PR TITLE
Release inventory-enabled application stack

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
+    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
     restart: unless-stopped
     hostname: backend
     logging: *default-logging
@@ -61,7 +61,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
+    image: slawekradzyminski/frontend:3.7.14@sha256:e76e75bb6228a746e0685b9efb3a6ec71bde2cbbb330afbd231d91c02fcbd67b
     restart: unless-stopped
     logging: *default-logging
     expose:
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   aitesters-backend:
-    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
+    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
     restart: unless-stopped
     hostname: aitesters-backend
     logging: *default-logging
@@ -110,7 +110,7 @@ services:
       - my-private-ntwk
 
   aitesters-frontend:
-    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
+    image: slawekradzyminski/frontend:3.7.14@sha256:e76e75bb6228a746e0685b9efb3a6ec71bde2cbbb330afbd231d91c02fcbd67b
     restart: unless-stopped
     logging: *default-logging
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full-native
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
+    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
     restart: always
     expose:
       - "4001"
@@ -63,7 +63,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
+    image: slawekradzyminski/frontend:3.7.14@sha256:e76e75bb6228a746e0685b9efb3a6ec71bde2cbbb330afbd231d91c02fcbd67b
     restart: always
     expose:
       - "80"

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -46,8 +46,8 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 
 | Service | Immutable image |
 | --- | --- |
-| Backend | `slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0` |
-| Frontend | `slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea` |
+| Backend | `slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac` |
+| Frontend | `slawekradzyminski/frontend:3.7.14@sha256:e76e75bb6228a746e0685b9efb3a6ec71bde2cbbb330afbd231d91c02fcbd67b` |
 | Consumer | `slawekradzyminski/consumer:3.3.7@sha256:545e2a091318e04d738915f19ba8a22220f943db108f76a9a31b296ca2cf1d61` |
 | Ollama mock | `slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab` |
 

--- a/experiments/llm-mutation/RESULTS.md
+++ b/experiments/llm-mutation/RESULTS.md
@@ -58,3 +58,21 @@ Raw execution records:
 - [`results/latest.json`](./results/latest.json): initial 4 killed / 4 survived;
 - [`results/after-strengthening.json`](./results/after-strengthening.json):
   8 killed / 0 survived.
+
+## Inventory feature extensions (2026-08-16)
+
+Four requirement-driven inventory mutants were added after the original pilot.
+They remain separate from the original eight-mutant score and were executed as
+bounded feature checks:
+
+| Mutant | Result | Requirement exercised |
+| --- | --- | --- |
+| backend removes the product lock | killed | concurrent checkout cannot sell the final unit twice |
+| backend commits a partial checkout | killed | multi-line checkout is atomic on a stock conflict |
+| backend restores cancelled stock twice | killed | cancellation compensation is exactly once |
+| frontend rotates the request ID after conflict | killed | an unchanged adjustment retry preserves its idempotency key |
+
+All four baseline copies passed, every mutant compiled, and the focused tests
+killed each mutant. Raw records are in
+[`results/inventory-backend.json`](./results/inventory-backend.json) and
+[`results/inventory-frontend.json`](./results/inventory-frontend.json).

--- a/experiments/llm-mutation/manifest.json
+++ b/experiments/llm-mutation/manifest.json
@@ -24,6 +24,36 @@
       "test": ["./mvnw", "-q", "-Dtest=AuthRateLimitGuardTest", "test"]
     },
     {
+      "id": "backend-inventory-product-lock-removed",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-inventory-product-lock-removed.patch",
+      "description": "Read stock without a pessimistic product lock, allowing competing checkouts to validate the same final unit.",
+      "contract": "Checkout must serialize product validation and deduction so one final unit produces one order and a stable HTTP 409 for the loser.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Pintegration-tests", "-Dskip.jacoco=true", "-Dtest=InventoryServiceTest", "-Dit.test=InventoryConcurrencyIT", "verify"]
+    },
+    {
+      "id": "backend-inventory-partial-checkout-committed",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-inventory-partial-checkout-committed.patch",
+      "description": "Persist the order and deduct each line while validation is still in progress, then commit a stock conflict.",
+      "contract": "A multi-line checkout is atomic: one unavailable line leaves every stock quantity, movement, order, and cart unchanged.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Pintegration-tests", "-Dskip.jacoco=true", "-Dtest=InventoryServiceTest", "-Dit.test=InventoryConcurrencyIT", "verify"]
+    },
+    {
+      "id": "backend-inventory-double-restoration",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-inventory-double-restoration.patch",
+      "description": "Allow cancellation of an already-cancelled order and leave its inventory state deducted so compensation runs again.",
+      "contract": "Cancellation restores deducted stock exactly once and transitions the internal inventory state to RESTORED.",
+      "compile": ["./mvnw", "-q", "-DskipTests", "compile"],
+      "test": ["./mvnw", "-q", "-Dtest=OrderServiceTest", "test"]
+    },
+    {
       "id": "frontend-sso-clears-pkce-before-exchange",
       "component": "frontend",
       "repository": "../vite-react-frontend",
@@ -52,6 +82,16 @@
       "contract": "Implicit training SSO is enabled only on the designated localhost:8081 gateway, never on unrelated loopback applications.",
       "compile": ["npm", "exec", "--", "tsc", "-b", "--pretty", "false"],
       "test": ["npm", "test", "--", "--run", "src/lib/runtimeConfig.test.ts"]
+    },
+    {
+      "id": "frontend-inventory-rotates-request-id-after-conflict",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-inventory-rotates-request-id-after-conflict.patch",
+      "description": "Generate a new adjustment request ID after a rejected attempt, turning an operator retry into a new inventory intent.",
+      "contract": "A failed or ambiguous inventory adjustment retains its UUID so retrying the unchanged form is idempotent; only success or a new selected-product intent rotates it.",
+      "compile": ["npm", "exec", "--", "tsc", "-b", "--pretty", "false"],
+      "test": ["npm", "test", "--", "--run", "src/components/admin/AdminInventory.test.tsx"]
     },
     {
       "id": "mock-tool-call-uses-token-delay",

--- a/experiments/llm-mutation/mutants/backend-inventory-double-restoration.patch
+++ b/experiments/llm-mutation/mutants/backend-inventory-double-restoration.patch
@@ -1,0 +1,14 @@
+diff --git a/src/main/java/com/awesome/testing/service/OrderService.java b/src/main/java/com/awesome/testing/service/OrderService.java
+--- a/src/main/java/com/awesome/testing/service/OrderService.java
++++ b/src/main/java/com/awesome/testing/service/OrderService.java
+@@ -148,3 +148,5 @@ public class OrderService {
+     private boolean canBeCancelled(OrderStatus status) {
+-        return status == OrderStatus.PENDING || status == OrderStatus.PAID;
++        return status == OrderStatus.PENDING
++                || status == OrderStatus.PAID
++                || status == OrderStatus.CANCELLED;
+     }
+@@ -166,3 +168,2 @@ public class OrderService {
+             });
+-            order.setInventoryState(InventoryState.RESTORED);
+         }

--- a/experiments/llm-mutation/mutants/backend-inventory-partial-checkout-committed.patch
+++ b/experiments/llm-mutation/mutants/backend-inventory-partial-checkout-committed.patch
@@ -1,0 +1,20 @@
+diff --git a/src/main/java/com/awesome/testing/service/OrderService.java b/src/main/java/com/awesome/testing/service/OrderService.java
+--- a/src/main/java/com/awesome/testing/service/OrderService.java
++++ b/src/main/java/com/awesome/testing/service/OrderService.java
+@@ -38,2 +38,2 @@ public class OrderService {
+-    @Transactional
++    @Transactional(noRollbackFor = CustomException.class)
+     public OrderDto createOrder(String username, AddressDto addressDto) {
+@@ -51,11 +51,9 @@ public class OrderService {
+                 .map(id -> productRepository.findByIdForUpdate(id)
+                         .orElseThrow(() -> new CustomException("Product not found", HttpStatus.NOT_FOUND)))
+                 .toList();
++        OrderEntity savedOrder = orderRepository.save(order);
+         for (ProductEntity product : locked) {
+             inventoryService.checkAvailable(product, quantities.get(product.getId()));
+-        }
+-        OrderEntity savedOrder = orderRepository.save(order);
+-        for (ProductEntity product : locked) {
+             inventoryService.deduct(product, quantities.get(product.getId()), savedOrder);
+         }
+         cartItemRepository.deleteByUsername(username);

--- a/experiments/llm-mutation/mutants/backend-inventory-product-lock-removed.patch
+++ b/experiments/llm-mutation/mutants/backend-inventory-product-lock-removed.patch
@@ -1,0 +1,7 @@
+diff --git a/src/main/java/com/awesome/testing/repository/ProductRepository.java b/src/main/java/com/awesome/testing/repository/ProductRepository.java
+--- a/src/main/java/com/awesome/testing/repository/ProductRepository.java
++++ b/src/main/java/com/awesome/testing/repository/ProductRepository.java
+@@ -18,3 +18,2 @@ public interface ProductRepository extends JpaRepository<ProductEntity, Long>, J
+-    @Lock(LockModeType.PESSIMISTIC_WRITE)
+     @Query("select p from ProductEntity p where p.id = :id")
+     Optional<ProductEntity> findByIdForUpdate(@Param("id") Long id);

--- a/experiments/llm-mutation/mutants/frontend-inventory-rotates-request-id-after-conflict.patch
+++ b/experiments/llm-mutation/mutants/frontend-inventory-rotates-request-id-after-conflict.patch
@@ -1,0 +1,7 @@
+diff --git a/src/components/admin/AdminInventory.tsx b/src/components/admin/AdminInventory.tsx
+--- a/src/components/admin/AdminInventory.tsx
++++ b/src/components/admin/AdminInventory.tsx
+@@ -85,2 +85,3 @@ export function AdminInventory() {
+     onError: (error) => {
++      setRequestId(crypto.randomUUID());
+       setAdjustmentError(isConflict(error)

--- a/experiments/llm-mutation/results/inventory-backend.json
+++ b/experiments/llm-mutation/results/inventory-backend.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "manifest": "/Users/slawek/IdeaProjects/awesome-localstack/experiments/llm-mutation/manifest.json",
+  "generationMode": "white-box semantic pilot",
+  "results": [
+    {
+      "id": "backend-inventory-product-lock-removed",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-inventory-product-lock-removed.patch",
+      "description": "Read stock without a pessimistic product lock, allowing competing checkouts to validate the same final unit.",
+      "contract": "Checkout must serialize product validation and deduction so one final unit produces one order and a stable HTTP 409 for the loser.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.657,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 10.826,
+        "outputTail": ")\n\tat org.hibernate.engine.jdbc.mutation.internal.AbstractMutationExecutor.execute(AbstractMutationExecutor.java:65)\n\tat org.hibernate.persister.entity.mutation.UpdateCoordinatorStandard.doStaticUpdate(UpdateCoordinatorStandard.java:861)\n\tat org.hibernate.persister.entity.mutation.UpdateCoordinatorStandard.performUpdate(UpdateCoordinatorStandard.java:336)\n\tat org.hibernate.persister.entity.mutation.UpdateCoordinatorStandard.update(UpdateCoordinatorStandard.java:251)\n\tat org.hibernate.action.internal.EntityUpdateAction.execute(EntityUpdateAction.java:161)\n\tat org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:634)\n\tat org.hibernate.engine.spi.ActionQueue.executeActions(ActionQueue.java:505)\n\tat org.hibernate.event.internal.AbstractFlushingEventListener.performExecutions(AbstractFlushingEventListener.java:381)\n\tat org.hibernate.event.internal.DefaultFlushEventListener.onFlush(DefaultFlushEventListener.java:40)\n\tat org.hibernate.event.service.internal.EventListenerGroupImpl.fireEventOnEachListener(EventListenerGroupImpl.java:138)\n\tat org.hibernate.internal.SessionImpl.fireFlush(SessionImpl.java:1458)\n\tat org.hibernate.internal.SessionImpl.managedFlush(SessionImpl.java:484)\n\tat org.hibernate.internal.SessionImpl.flushBeforeTransactionCompletion(SessionImpl.java:2086)\n\tat org.hibernate.internal.SessionImpl.beforeTransactionCompletion(SessionImpl.java:2007)\n\tat org.hibernate.engine.jdbc.internal.JdbcCoordinatorImpl.beforeTransactionCompletion(JdbcCoordinatorImpl.java:426)\n\tat org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl.beforeCompletionCallback(JdbcResourceLocalTransactionCoordinatorImpl.java:167)\n\tat org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commitNoRollbackOnly(JdbcResourceLocalTransactionCoordinatorImpl.java:252)\n\tat org.hibernate.resource.transaction.backend.jdbc.internal.JdbcResourceLocalTransactionCoordinatorImpl$TransactionDriverControlImpl.commit(JdbcResourceLocalTransactionCoordinatorImpl.java:242)\n\tat org.hibernate.engine.transaction.internal.TransactionImpl.commit(TransactionImpl.java:89)\n\tat org.springframework.orm.jpa.JpaTransactionManager.doCommit(JpaTransactionManager.java:552)\n\t... 10 more\nCaused by: org.hibernate.StaleStateException: Unexpected row count (expected row count 1 but was 0) [update products set category=?,description=?,image_url=?,name=?,price=?,stock_quantity=?,updated_at=?,version=? where id=? and version=?]\n\tat org.hibernate.jdbc.Expectations.checkNonBatched(Expectations.java:93)\n\tat org.hibernate.jdbc.Expectation$RowCount.verifyOutcome(Expectation.java:170)\n\tat org.hibernate.engine.jdbc.mutation.internal.ModelMutationHelper.identifiedResultsCheck(ModelMutationHelper.java:57)\n\t... 35 more\n\n[ERROR] Errors: \n[ERROR]   InventoryConcurrencyIT.onlyOneBuyerCanCheckoutTheFinalUnit:112 \u00bb Execution org.springframework.orm.ObjectOptimisticLockingFailureException: Unexpected row count (expected row count 1 but was 0) [update products set category=?,description=?,image_url=?,name=?,price=?,stock_quantity=?,updated_at=?,version=? where id=? and version=?] for entity [com.awesome.testing.entity.ProductEntity with id '1']\n[ERROR] Tests run: 3, Failures: 0, Errors: 1, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.28.0:check (default) on project jwt-auth-service: PMD 7.17.0 has found 2 violations. For more details see: /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-0o08e08j/backend-inventory-product-lock-removed/target/pmd.xml -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.696,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 11.282,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "backend-inventory-partial-checkout-committed",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-inventory-partial-checkout-committed.patch",
+      "description": "Persist the order and deduct each line while validation is still in progress, then commit a stock conflict.",
+      "contract": "A multi-line checkout is atomic: one unavailable line leaves every stock quantity, movement, order, and cart unchanged.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.283,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 10.249,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0, Time elapsed: 4.106 s <<< FAILURE! -- in com.awesome.testing.service.InventoryConcurrencyIT\n[ERROR] com.awesome.testing.service.InventoryConcurrencyIT.onlyOneBuyerCanCheckoutTheFinalUnit -- Time elapsed: 0.205 s <<< FAILURE!\norg.opentest4j.AssertionFailedError: \n\nexpected: 1L\n but was: 2L\n\tat com.awesome.testing.service.InventoryConcurrencyIT.onlyOneBuyerCanCheckoutTheFinalUnit(InventoryConcurrencyIT.java:117)\n\n[ERROR] com.awesome.testing.service.InventoryConcurrencyIT.unavailableLineRollsBackTheEntireCheckout -- Time elapsed: 0.029 s <<< FAILURE!\norg.opentest4j.AssertionFailedError: \n\nexpected: 2\n but was: 1\n\tat com.awesome.testing.service.InventoryConcurrencyIT.unavailableLineRollsBackTheEntireCheckout(InventoryConcurrencyIT.java:159)\n\n[ERROR] Failures: \n[ERROR]   InventoryConcurrencyIT.onlyOneBuyerCanCheckoutTheFinalUnit:117 \nexpected: 1L\n but was: 2L\n[ERROR]   InventoryConcurrencyIT.unavailableLineRollsBackTheEntireCheckout:159 \nexpected: 2\n but was: 1\n[ERROR] Tests run: 3, Failures: 2, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-failsafe-plugin:3.5.6:verify (default) on project jwt-auth-service: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-g8vll9zd/backend-inventory-partial-checkout-committed/target/failsafe-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.369,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 10.31,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "backend-inventory-double-restoration",
+      "component": "backend",
+      "repository": "../test-secure-backend",
+      "patch": "mutants/backend-inventory-double-restoration.patch",
+      "description": "Allow cancellation of an already-cancelled order and leave its inventory state deducted so compensation runs again.",
+      "contract": "Cancellation restores deducted stock exactly once and transitions the internal inventory state to RESTORED.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 3.394,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 4.408,
+        "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.680 s <<< FAILURE! -- in com.awesome.testing.service.OrderServiceTest\n[ERROR] com.awesome.testing.service.OrderServiceTest.shouldRestoreDeductedInventoryExactlyOnceWhenOrderIsCancelled -- Time elapsed: 0.011 s <<< FAILURE!\norg.opentest4j.AssertionFailedError: \n\nexpected: RESTORED\n but was: DEDUCTED\n\tat com.awesome.testing.service.OrderServiceTest.shouldRestoreDeductedInventoryExactlyOnceWhenOrderIsCancelled(OrderServiceTest.java:177)\n\n[ERROR] Failures: \n[ERROR]   OrderServiceTest.shouldRestoreDeductedInventoryExactlyOnceWhenOrderIsCancelled:177 \nexpected: RESTORED\n but was: DEDUCTED\n[ERROR] Tests run: 11, Failures: 1, Errors: 0, Skipped: 0\n[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.5.6:test (default-test) on project jwt-auth-service: There are test failures.\n[ERROR] \n[ERROR] See /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-krx6557r/backend-inventory-double-restoration/target/surefire-reports for the individual test results.\n[ERROR] See dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.\n[ERROR] -> [Help 1]\n[ERROR] \n[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.\n[ERROR] Re-run Maven using the -X switch to enable full debug logging.\n[ERROR] \n[ERROR] For more information about the errors and possible solutions, please read the following articles:\n[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 3.281,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 4.43,
+          "outputTail": "Picked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nWARNING: A terminally deprecated method in sun.misc.Unsafe has been called\nWARNING: sun.misc.Unsafe::objectFieldOffset has been called by lombok.permit.Permit\nWARNING: Please consider reporting this to the maintainers of class lombok.permit.Permit\nWARNING: sun.misc.Unsafe::objectFieldOffset will be removed in a future release\nPicked up JAVA_TOOL_OPTIONS: -Duser.language=en -Duser.country=US\nOpenJDK 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended\n",
+          "timedOut": false
+        }
+      }
+    }
+  ],
+  "summary": {
+    "killed": 3
+  }
+}

--- a/experiments/llm-mutation/results/inventory-frontend.json
+++ b/experiments/llm-mutation/results/inventory-frontend.json
@@ -1,0 +1,46 @@
+{
+  "schemaVersion": 1,
+  "manifest": "/Users/slawek/IdeaProjects/awesome-localstack/experiments/llm-mutation/manifest.json",
+  "generationMode": "white-box semantic pilot",
+  "results": [
+    {
+      "id": "frontend-inventory-rotates-request-id-after-conflict",
+      "component": "frontend",
+      "repository": "../vite-react-frontend",
+      "patch": "mutants/frontend-inventory-rotates-request-id-after-conflict.patch",
+      "description": "Generate a new adjustment request ID after a rejected attempt, turning an operator retry into a new inventory intent.",
+      "contract": "A failed or ambiguous inventory adjustment retains its UUID so retrying the unchanged form is idempotent; only success or a new selected-product intent rotates it.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 2.041,
+        "outputTail": "",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 1.081,
+        "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/components/admin/AdminInventory.test.tsx\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-4h6fy8tv/frontend-inventory-rotates-request-id-after-conflict\n\n \u276f src/components/admin/AdminInventory.test.tsx (6 tests | 1 failed) 468ms\n     \u00d7 validates adjustments and preserves the request id across a failed retry 101ms\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af Failed Tests 1 \u23af\u23af\u23af\u23af\u23af\u23af\u23af\n\n FAIL  src/components/admin/AdminInventory.test.tsx > AdminInventory > validates adjustments and preserves the request id across a failed retry\nAssertionError: expected '22222222-2222-4222-8222-222222222222' to be '11111111-1111-4111-8111-111111111111' // Object.is equality\n\nExpected: \"11111111-1111-4111-8111-111111111111\"\nReceived: \"22222222-2222-4222-8222-222222222222\"\n\n \u276f src/components/admin/AdminInventory.test.tsx:197:68\n    195|     await user.click(screen.getByRole('button', { name: 'Apply adjustm\u2026\n    196|     await waitFor(() => expect(inventory.adjust).toHaveBeenCalledTimes\u2026\n    197|     expect(vi.mocked(inventory.adjust).mock.calls[1][1].requestId).toB\u2026\n       |                                                                    ^\n    198|     await waitFor(() => expect(screen.getByLabelText('Quantity change'\u2026\n    199|     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['inventory\u2026\n\n\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af\u23af[1/1]\u23af\n\n\n Test Files  1 failed (1)\n      Tests  1 failed | 5 passed (6)\n   Start at  15:41:18\n   Duration  845ms (transform 42ms, setup 42ms, import 86ms, tests 468ms, environment 198ms)\n\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.594,
+          "outputTail": "",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 1.165,
+          "outputTail": "\n> vite@3.7.13 test\n> vitest run --run src/components/admin/AdminInventory.test.tsx\n\n\n RUN  v4.1.10 /private/var/folders/hc/_qs8lmtj3wldtbls_clrl0980000gn/T/llm-mutant-baseline-6cjrttrv/frontend-inventory-rotates-request-id-after-conflict\n\n\n Test Files  1 passed (1)\n      Tests  6 passed (6)\n   Start at  15:41:14\n   Duration  935ms (transform 51ms, setup 51ms, import 97ms, tests 525ms, environment 210ms)\n\n",
+          "timedOut": false
+        }
+      }
+    }
+  ],
+  "summary": {
+    "killed": 1
+  }
+}

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.15@sha256:3a4255b3d51d7cbc4e8690f9f9608487114dd24fa526c1bd897895dbe1143bf0
+    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
     restart: always
     expose:
       - "4001"
@@ -38,7 +38,7 @@ services:
       - my-private-ntwk
 
   frontend:
-    image: slawekradzyminski/frontend:3.7.13@sha256:8f7e5cb457d277c9dd85098cb1354a646830c544d78bddca2a110ec8e1591cea
+    image: slawekradzyminski/frontend:3.7.14@sha256:e76e75bb6228a746e0685b9efb3a6ec71bde2cbbb330afbd231d91c02fcbd67b
     restart: always
     expose:
       - "80"


### PR DESCRIPTION
## Summary
- pin backend 3.7.16 and frontend 3.7.14 by immutable Docker Hub digests across full, lightweight, server, and aitesters services
- update the documented compatibility set
- record the four killed inventory semantic mutants for backend locking/restoration and frontend idempotency behavior

## Verification
- docker compose config --quiet for full, server, and lightweight profiles
- docker compose full + model-mock merged config
- make sync-release-images
- python3 scripts/verify-release-images.py --remote
- python3 scripts/verify-image-pins.py
- bash scripts/verify-ollama-config.sh
- local lightweight backend direct health and proxied health/OpenAPI/login/image routes
- backend and frontend containers resolved to the new immutable images

## Local ARM note
The pre-existing ollama-mock 1.0.9 arm64 manifest advertises Bonsai rather than the qwen3.5:2b model used by the amd64 CI gate. Application routes and the changed images passed locally; the repository CI remains the authoritative amd64 full/lightweight compatibility gate.