### PR TITLE
Silence planned deployment warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,13 @@ permissions:
   contents: read
 
 jobs:
+  verifyDeploymentSilence:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.1
+    - name: Verify bounded deployment alert silence
+      run: python3 scripts/verify-deployment-silence.py
+
   verifyEdgeProxy:
     runs-on: ubuntu-latest
     steps:

--- a/ansible/playbooks/deploy.yml
+++ b/ansible/playbooks/deploy.yml
@@ -6,6 +6,10 @@
   roles:
     - swap
     - postgres_backup
+    - role: deployment_silence
+      deployment_silence_state: present
     - app
     - verify
+    - role: deployment_silence
+      deployment_silence_state: absent
     - cleanup

--- a/ansible/roles/deployment_silence/defaults/main.yml
+++ b/ansible/roles/deployment_silence/defaults/main.yml
@@ -1,0 +1,4 @@
+deployment_silence_state: present
+deployment_silence_duration_minutes: 15
+deployment_silence_created_by: ansible-deploy
+deployment_silence_comment: Planned Awesome Server deployment

--- a/ansible/roles/deployment_silence/tasks/absent.yml
+++ b/ansible/roles/deployment_silence/tasks/absent.yml
@@ -1,0 +1,27 @@
+- name: Expire the deployment silence after successful verification
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - gateway
+      - curl
+      - --fail
+      - --silent
+      - --show-error
+      - --request
+      - DELETE
+      - "http://alertmanager:9093/api/v2/silence/{{ deployment_silence_id }}"
+    chdir: "{{ app_dir }}"
+  changed_when: true
+  when: deployment_silence_id is defined
+
+- name: Report expired deployment silence
+  ansible.builtin.debug:
+    msg: >-
+      Expired the planned deployment warning silence after successful
+      verification; normal warning notifications are active again.
+  when: deployment_silence_id is defined

--- a/ansible/roles/deployment_silence/tasks/main.yml
+++ b/ansible/roles/deployment_silence/tasks/main.yml
@@ -1,0 +1,14 @@
+- name: Validate deployment silence state
+  ansible.builtin.assert:
+    that:
+      - deployment_silence_state in ['present', 'absent']
+      - deployment_silence_duration_minutes | int >= 5
+    quiet: true
+
+- name: Create the deployment silence
+  ansible.builtin.include_tasks: present.yml
+  when: deployment_silence_state == 'present'
+
+- name: Expire the deployment silence
+  ansible.builtin.include_tasks: absent.yml
+  when: deployment_silence_state == 'absent'

--- a/ansible/roles/deployment_silence/tasks/present.yml
+++ b/ansible/roles/deployment_silence/tasks/present.yml
@@ -1,0 +1,155 @@
+- name: Check for an existing deployed Compose file
+  ansible.builtin.stat:
+    path: "{{ app_dir }}/{{ app_compose_file }}"
+  register: deployment_silence_compose
+
+- name: Check whether Alertmanager is running
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - ps
+      - --status
+      - running
+      - --quiet
+      - alertmanager
+    chdir: "{{ app_dir }}"
+  register: deployment_silence_alertmanager
+  changed_when: false
+  failed_when: false
+  when: deployment_silence_compose.stat.exists
+
+- name: Check whether the gateway is running
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - ps
+      - --status
+      - running
+      - --quiet
+      - gateway
+    chdir: "{{ app_dir }}"
+  register: deployment_silence_gateway
+  changed_when: false
+  failed_when: false
+  when: deployment_silence_compose.stat.exists
+
+- name: Record deployment silence availability
+  ansible.builtin.set_fact:
+    deployment_silence_available: >-
+      {{
+        deployment_silence_compose.stat.exists
+        and deployment_silence_alertmanager is not skipped
+        and deployment_silence_alertmanager.rc == 0
+        and deployment_silence_alertmanager.stdout | length > 0
+        and deployment_silence_gateway is not skipped
+        and deployment_silence_gateway.rc == 0
+        and deployment_silence_gateway.stdout | length > 0
+      }}
+
+- name: Explain why no deployment silence was created
+  ansible.builtin.debug:
+    msg: >-
+      The existing Alertmanager path is unavailable, so this first-time or
+      recovery deployment will continue without a maintenance silence.
+  when: not deployment_silence_available | bool
+
+- name: Record deployment silence time bounds
+  ansible.builtin.set_fact:
+    deployment_silence_starts_at: >-
+      {{ '%Y-%m-%dT%H:%M:%SZ' | strftime(ansible_date_time.epoch | int, utc=true) }}
+    deployment_silence_ends_at: >-
+      {{
+        '%Y-%m-%dT%H:%M:%SZ'
+        | strftime(
+            (ansible_date_time.epoch | int)
+            + ((deployment_silence_duration_minutes | int) * 60),
+            utc=true
+          )
+      }}
+  when: deployment_silence_available | bool
+
+- name: Build deployment silence payload
+  ansible.builtin.set_fact:
+    deployment_silence_payload: >-
+      {{
+        {
+          'matchers': [
+            {
+              'name': 'alertname',
+              'value': 'PublicEndpointProbeFailed',
+              'isRegex': false,
+              'isEqual': true
+            },
+            {
+              'name': 'job',
+              'value': 'public_https',
+              'isRegex': false,
+              'isEqual': true
+            },
+            {
+              'name': 'service',
+              'value': 'public-edge',
+              'isRegex': false,
+              'isEqual': true
+            }
+          ],
+          'startsAt': deployment_silence_starts_at,
+          'endsAt': deployment_silence_ends_at,
+          'createdBy': deployment_silence_created_by,
+          'comment': deployment_silence_comment
+        }
+        | to_json
+      }}
+  when: deployment_silence_available | bool
+
+- name: Silence planned public endpoint warnings during deployment
+  ansible.builtin.command:
+    argv:
+      - docker
+      - compose
+      - -f
+      - "{{ app_compose_file }}"
+      - exec
+      - -T
+      - gateway
+      - curl
+      - --fail
+      - --silent
+      - --show-error
+      - --request
+      - POST
+      - http://alertmanager:9093/api/v2/silences
+      - --header
+      - "Content-Type: application/json"
+      - --data
+      - "{{ deployment_silence_payload }}"
+    chdir: "{{ app_dir }}"
+  register: deployment_silence_create
+  changed_when: true
+  when: deployment_silence_available | bool
+
+- name: Record the deployment silence identifier
+  ansible.builtin.set_fact:
+    deployment_silence_id: "{{ (deployment_silence_create.stdout | from_json).silenceID }}"
+  when: deployment_silence_available | bool
+
+- name: Verify the deployment silence was created
+  ansible.builtin.assert:
+    that:
+      - deployment_silence_id | length > 0
+    fail_msg: Alertmanager did not return a deployment silence identifier
+    quiet: true
+  when: deployment_silence_available | bool
+
+- name: Report deployment silence
+  ansible.builtin.debug:
+    msg: >-
+      Silenced PublicEndpointProbeFailed warnings until
+      {{ deployment_silence_ends_at }}; critical endpoint alerts remain active.
+  when: deployment_silence_available | bool

--- a/docs/ANSIBLE.md
+++ b/docs/ANSIBLE.md
@@ -32,6 +32,7 @@ ansible/
     docker/
     swap/
     postgres_backup/
+    deployment_silence/
     app/
     verify/
     cleanup/
@@ -124,18 +125,23 @@ ansible-vault encrypt inventory/group_vars/production/vault.yml --vault-password
 
 `deploy.yml` is the normal operational entrypoint.
 
-It performs five steps in order:
+It performs seven steps in order:
 
 1. Runs the guarded `swap` role. It can converge a 1 GiB emergency swap file
    and low swappiness on capable hosts; it reports a tracked reason and makes no
    swap changes on the current MIKR.US LXC host.
 2. Runs the `postgres_backup` role and creates the encrypted pre-deploy backup.
-3. Runs the `app` role to reconcile the existing PostgreSQL role with the
+3. Creates a 15-minute Alertmanager silence for the warning-level
+   `PublicEndpointProbeFailed` alert when the existing monitoring stack is
+   reachable. The five-minute critical alert remains active.
+4. Runs the `app` role to reconcile the existing PostgreSQL role with the
    Vault-managed password, render the protected runtime environment, and
    converge files and Docker Compose state in `/opt/awesome-localstack`.
-4. Runs the `verify` role to make sure the deployed stack is actually
+5. Runs the `verify` role to make sure the deployed stack is actually
    reachable.
-5. Runs the guarded `cleanup` role only after verification succeeds.
+6. Expires the warning silence immediately after verification succeeds. If a
+   deploy fails first, the silence expires automatically after 15 minutes.
+7. Runs the guarded `cleanup` role only after verification succeeds.
 
 This is intentional. In this project, a deploy that leaves the gateway returning `502` is a failed deploy, not a successful deploy with a separate follow-up check.
 
@@ -209,6 +215,8 @@ For that reason, HTTP verification uses retries and delay rather than failing im
 - `swap`: guarded emergency-swap convergence; disabled on the current LXC host
   because the provider rejects `swapon`
 - `postgres_backup`: encrypted backups, restore checks, and the pre-deploy backup
+- `deployment_silence`: bounded suppression of planned warning-level public
+  endpoint alerts; critical endpoint alerts are never silenced
 - `app`: file sync, runtime env rendering, Compose convergence
 - `verify`: operational checks after deploy
 - `cleanup`: checksum- and age-guarded retirement of the legacy Artemis volume

--- a/experiments/llm-mutation/manifest.json
+++ b/experiments/llm-mutation/manifest.json
@@ -4,6 +4,26 @@
   "generationMode": "white-box semantic pilot",
   "mutants": [
     {
+      "id": "stack-deploy-silences-critical-endpoint-alert",
+      "component": "stack",
+      "repository": ".",
+      "patch": "mutants/stack-deploy-silences-critical-endpoint-alert.patch",
+      "description": "Silence the critical endpoint alert during a planned deployment instead of the warning alert.",
+      "contract": "Deployments may suppress the two-minute public endpoint warning, but the five-minute critical alert must remain active.",
+      "compile": ["bash", "-lc", "cd ansible && ansible-playbook playbooks/deploy.yml --syntax-check --vault-password-file .vault_pass"],
+      "test": ["python3", "scripts/verify-deployment-silence.py"]
+    },
+    {
+      "id": "stack-deploy-expires-silence-before-verification",
+      "component": "stack",
+      "repository": ".",
+      "patch": "mutants/stack-deploy-expires-silence-before-verification.patch",
+      "description": "Expire the maintenance silence immediately after Compose convergence while verification is still running.",
+      "contract": "The planned warning silence must remain active until post-deployment verification succeeds.",
+      "compile": ["bash", "-lc", "cd ansible && ansible-playbook playbooks/deploy.yml --syntax-check --vault-password-file .vault_pass"],
+      "test": ["python3", "scripts/verify-deployment-silence.py"]
+    },
+    {
       "id": "backend-partial-sso-account-blocked",
       "component": "backend",
       "repository": "../test-secure-backend",

--- a/experiments/llm-mutation/mutants/stack-deploy-expires-silence-before-verification.patch
+++ b/experiments/llm-mutation/mutants/stack-deploy-expires-silence-before-verification.patch
@@ -1,0 +1,12 @@
+diff --git a/ansible/playbooks/deploy.yml b/ansible/playbooks/deploy.yml
+--- a/ansible/playbooks/deploy.yml
++++ b/ansible/playbooks/deploy.yml
+@@ -9,7 +9,7 @@
+     - role: deployment_silence
+       deployment_silence_state: present
+     - app
+-    - verify
+     - role: deployment_silence
+       deployment_silence_state: absent
++    - verify
+     - cleanup

--- a/experiments/llm-mutation/mutants/stack-deploy-silences-critical-endpoint-alert.patch
+++ b/experiments/llm-mutation/mutants/stack-deploy-silences-critical-endpoint-alert.patch
@@ -1,0 +1,12 @@
+diff --git a/ansible/roles/deployment_silence/tasks/present.yml b/ansible/roles/deployment_silence/tasks/present.yml
+--- a/ansible/roles/deployment_silence/tasks/present.yml
++++ b/ansible/roles/deployment_silence/tasks/present.yml
+@@ -82,7 +82,7 @@
+           'matchers': [
+             {
+               'name': 'alertname',
+-              'value': 'PublicEndpointProbeFailed',
++              'value': 'PublicEndpointProbeFailedCritical',
+               'isRegex': false,
+               'isEqual': true
+             },

--- a/experiments/llm-mutation/results/deployment-silence.json
+++ b/experiments/llm-mutation/results/deployment-silence.json
@@ -1,0 +1,82 @@
+{
+  "schemaVersion": 1,
+  "manifest": "/Users/slawek/IdeaProjects/awesome-localstack/experiments/llm-mutation/manifest.json",
+  "generationMode": "white-box semantic pilot",
+  "results": [
+    {
+      "id": "stack-deploy-silences-critical-endpoint-alert",
+      "component": "stack",
+      "repository": ".",
+      "patch": "mutants/stack-deploy-silences-critical-endpoint-alert.patch",
+      "description": "Silence the critical endpoint alert during a planned deployment instead of the warning alert.",
+      "contract": "Deployments may suppress the two-minute public endpoint warning, but the five-minute critical alert must remain active.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.488,
+        "outputTail": "\nplaybook: playbooks/deploy.yml\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.023,
+        "outputTail": "Deployment silence contract failed: the warning alert must be silenced\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.514,
+          "outputTail": "\nplaybook: playbooks/deploy.yml\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.026,
+          "outputTail": "Deployment silence contract verified\n",
+          "timedOut": false
+        }
+      }
+    },
+    {
+      "id": "stack-deploy-expires-silence-before-verification",
+      "component": "stack",
+      "repository": ".",
+      "patch": "mutants/stack-deploy-expires-silence-before-verification.patch",
+      "description": "Expire the maintenance silence immediately after Compose convergence while verification is still running.",
+      "contract": "The planned warning silence must remain active until post-deployment verification succeeds.",
+      "compile": {
+        "exitCode": 0,
+        "durationSeconds": 0.449,
+        "outputTail": "\nplaybook: playbooks/deploy.yml\n",
+        "timedOut": false
+      },
+      "test": {
+        "exitCode": 1,
+        "durationSeconds": 0.021,
+        "outputTail": "Deployment silence contract failed: silence must wrap app convergence and verification\n",
+        "timedOut": false
+      },
+      "status": "killed",
+      "baseline": {
+        "status": "passed",
+        "compile": {
+          "exitCode": 0,
+          "durationSeconds": 0.43,
+          "outputTail": "\nplaybook: playbooks/deploy.yml\n",
+          "timedOut": false
+        },
+        "test": {
+          "exitCode": 0,
+          "durationSeconds": 0.022,
+          "outputTail": "Deployment silence contract verified\n",
+          "timedOut": false
+        }
+      }
+    }
+  ],
+  "summary": {
+    "killed": 2
+  }
+}

--- a/scripts/verify-deployment-silence.py
+++ b/scripts/verify-deployment-silence.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Verify the production deployment-alert silence contract."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PLAYBOOK = ROOT / "ansible/playbooks/deploy.yml"
+DEFAULTS = ROOT / "ansible/roles/deployment_silence/defaults/main.yml"
+PRESENT = ROOT / "ansible/roles/deployment_silence/tasks/present.yml"
+ABSENT = ROOT / "ansible/roles/deployment_silence/tasks/absent.yml"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"Deployment silence contract failed: {message}")
+
+
+def ordered_positions(text: str, markers: list[str]) -> list[int]:
+    positions = [text.find(marker) for marker in markers]
+    require(all(position >= 0 for position in positions), "deploy role sequence is incomplete")
+    return positions
+
+
+def main() -> None:
+    playbook = PLAYBOOK.read_text()
+    defaults = DEFAULTS.read_text()
+    present = PRESENT.read_text()
+    absent = ABSENT.read_text()
+
+    positions = ordered_positions(
+        playbook,
+        [
+            "deployment_silence_state: present",
+            "    - app",
+            "    - verify",
+            "deployment_silence_state: absent",
+            "    - cleanup",
+        ],
+    )
+    require(positions == sorted(positions), "silence must wrap app convergence and verification")
+    require(
+        "deployment_silence_duration_minutes: 15" in defaults,
+        "the automatic safety expiry must remain 15 minutes",
+    )
+    require(
+        "'value': 'PublicEndpointProbeFailed'" in present,
+        "the warning alert must be silenced",
+    )
+    require(
+        "'value': 'PublicEndpointProbeFailedCritical'" not in present,
+        "the critical alert must never be silenced",
+    )
+    require("'value': 'public_https'" in present, "silence must target the public probe job")
+    require("'value': 'public-edge'" in present, "silence must target the public edge service")
+    require(
+        "(deployment_silence_duration_minutes | int) * 60" in present,
+        "Alertmanager endsAt must use the bounded duration",
+    )
+    require(
+        "/api/v2/silence/{{ deployment_silence_id }}" in absent,
+        "successful verification must expire the exact created silence",
+    )
+
+    print("Deployment silence contract verified")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create an exact-match Alertmanager silence for the warning-level public endpoint probe during deployments
- keep the critical endpoint alert active and bound the silence to 15 minutes
- expire the silence immediately after successful production verification
- add CI contract coverage and two killed semantic deployment mutants

## Verification
- `python3 scripts/verify-deployment-silence.py`
- `ansible-playbook playbooks/deploy.yml --syntax-check --vault-password-file .vault_pass`
- `ansible-playbook playbooks/verify.yml --syntax-check --vault-password-file .vault_pass`
- semantic mutation lab: 2 killed, 0 survived/invalid/equivalent
- `git diff --check`