### PR TITLE
Use namespaced Ansible date facts

### DIFF
--- a/ansible/roles/deployment_silence/tasks/present.yml
+++ b/ansible/roles/deployment_silence/tasks/present.yml
@@ -62,12 +62,15 @@
 - name: Record deployment silence time bounds
   ansible.builtin.set_fact:
     deployment_silence_starts_at: >-
-      {{ '%Y-%m-%dT%H:%M:%SZ' | strftime(ansible_date_time.epoch | int, utc=true) }}
+      {{
+        '%Y-%m-%dT%H:%M:%SZ'
+        | strftime(ansible_facts['date_time']['epoch'] | int, utc=true)
+      }}
     deployment_silence_ends_at: >-
       {{
         '%Y-%m-%dT%H:%M:%SZ'
         | strftime(
-            (ansible_date_time.epoch | int)
+            (ansible_facts['date_time']['epoch'] | int)
             + ((deployment_silence_duration_minutes | int) * 60),
             utc=true
           )


### PR DESCRIPTION
## Summary
- use the supported namespaced gathered-fact access in deployment silence timestamps
- remove the deprecation warning observed during the production deployment

## Verification
- deployment silence contract passed
- deploy playbook syntax check passed
- both deployment semantic mutants killed
- production deployment and API checks were already successful in #47