### PR TITLE
Deploy backend 3.7.17 with corrected OpenAPI contracts

### DIFF
--- a/docker-compose.server.yml
+++ b/docker-compose.server.yml
@@ -8,7 +8,7 @@ x-default-logging: &default-logging
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
+    image: slawekradzyminski/backend:3.7.17@sha256:1828d15e4344f397ff5b03067b43fd3bbedcd5d46939184e6afbb9bef020693b
     restart: unless-stopped
     hostname: backend
     logging: *default-logging
@@ -71,7 +71,7 @@ services:
       - my-private-ntwk
 
   aitesters-backend:
-    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
+    image: slawekradzyminski/backend:3.7.17@sha256:1828d15e4344f397ff5b03067b43fd3bbedcd5d46939184e6afbb9bef020693b
     restart: unless-stopped
     hostname: aitesters-backend
     logging: *default-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-full-native
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
+    image: slawekradzyminski/backend:3.7.17@sha256:1828d15e4344f397ff5b03067b43fd3bbedcd5d46939184e6afbb9bef020693b
     restart: always
     expose:
       - "4001"

--- a/docs/CONTAINER_RELEASES.md
+++ b/docs/CONTAINER_RELEASES.md
@@ -46,10 +46,18 @@ Dependabot monitors the `github-actions` ecosystem in every source repository. R
 
 | Service | Immutable image |
 | --- | --- |
-| Backend | `slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac` |
+| Backend | `slawekradzyminski/backend:3.7.17@sha256:1828d15e4344f397ff5b03067b43fd3bbedcd5d46939184e6afbb9bef020693b` |
 | Frontend | `slawekradzyminski/frontend:3.7.14@sha256:e76e75bb6228a746e0685b9efb3a6ec71bde2cbbb330afbd231d91c02fcbd67b` |
 | Consumer | `slawekradzyminski/consumer:3.3.7@sha256:545e2a091318e04d738915f19ba8a22220f943db108f76a9a31b296ca2cf1d61` |
 | Ollama mock | `slawekradzyminski/ollama-mock:1.0.9@sha256:24852d0f78eb7ed208bb1eaaab1d912d29e5e74d6c28c2e6a31dd1cbcdedbdab` |
+
+## Backend 3.7.17 release
+
+Backend source: [PR #56](https://github.com/slawekradzyminski/test-secure-backend/pull/56), commit `b4973a53b1697f84a479b6aceeb870cd48423091`. The [release workflow](https://github.com/slawekradzyminski/test-secure-backend/actions/runs/34686783798) passed Maven, integration, local-startup, and Docker gates and published both supported architectures.
+
+This release corrects generated OpenAPI contracts and includes the previously merged pagination, cart/order, and QR cleanup. It introduces no database migrations. The unchanged lesson `l20` suite passed all 190 tests against backend 3.7.16 before rollout; the same suite is the post-deployment compatibility gate.
+
+Rollback backend reference: `slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac`. Restore that reference consistently across the Compose profiles, synchronize the sibling development references, validate the files, and redeploy through Ansible. Preserve runtime configuration and database volumes.
 
 ## LocalStack compatibility gate
 

--- a/lightweight-docker-compose.yml
+++ b/lightweight-docker-compose.yml
@@ -2,7 +2,7 @@ name: awesome-light
 
 services:
   backend:
-    image: slawekradzyminski/backend:3.7.16@sha256:71cd8913a276f613200f35c83e846a0aa647a9313fa3e5e5f741390f4dc2dbac
+    image: slawekradzyminski/backend:3.7.17@sha256:1828d15e4344f397ff5b03067b43fd3bbedcd5d46939184e6afbb9bef020693b
     restart: always
     expose:
       - "4001"


### PR DESCRIPTION
Deployed backend 3.7.17 to `awesome.byst.re` and `aitesters.byst.re` with Docker Hub digest `sha256:1828d15e4344f397ff5b03067b43fd3bbedcd5d46939184e6afbb9bef020693b`. The full, lightweight, and server profiles share the immutable release; the compatibility runbook records the source and previous image for rollback. Other application images and the live runtime configuration were preserved.

The release corrects generated OpenAPI contracts and includes the previously merged pagination, cart/order, and QR cleanup. It adds no database migrations. Backend source: [PR #56](https://github.com/slawekradzyminski/test-secure-backend/pull/56), commit `b4973a53b1697f84a479b6aceeb870cd48423091`.

Validation on 2026-09-12:

- [Backend release gates](https://github.com/slawekradzyminski/test-secure-backend/actions/runs/34686783798): passed, including Maven, integration, local startup, Docker verification, and amd64/arm64 publication.
- [Stack CI](https://github.com/slawekradzyminski/awesome-localstack/actions/runs/34687371947): all seven jobs passed, including the full and lightweight stacks.
- Modified Compose files passed `docker compose config --quiet`; local image-pin and remote manifest checks passed. Sibling development image references were synchronized.
- Ansible deployment completed after the encrypted pre-deployment backup: 108 OK, 14 changed, zero failed/unreachable tasks. Image identity, routing, monitoring, and email delivery checks passed.
- Direct service and public OpenAPI checks confirmed the corrected schemas and preservation of all 53 main / 55 sandbox operations.
- The unchanged latest lesson `l20` suite at course commit `64d2a452cd502f062af6b67f074e77a56ff4e793` passed 190/190 tests on 3.7.16 before rollout, and 190/190 on deployed 3.7.17 afterward (4.9 minutes; zero failures, skips, or flaky results). Both API and administrator projects used their normal public domains.

No course tests were modified and no rollback was required.
